### PR TITLE
#11 | remove HttpClientModule deprecated import

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ npx ng serve
 
 Fast
 ```bash
-nvm use v22.12.0; rm .angular/ -fr; npx ng serve
+nvm use v22.12.0; rm .angular/ node_modules -fr; npm i; npx ng serve
 ```

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,7 +2,7 @@
 
 import { ApplicationConfig, provideZoneChangeDetection, importProvidersFrom } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { HttpClientModule } from '@angular/common/http';
+import { withInterceptorsFromDi, provideHttpClient } from '@angular/common/http';
 import { routes } from './app.routes';
 import { StoreModule } from '@ngrx/store';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
@@ -13,7 +13,7 @@ export const appConfig: ApplicationConfig = {
     providers: [
         provideZoneChangeDetection({ eventCoalescing: true }),
         provideRouter(routes),
-        importProvidersFrom(HttpClientModule),
+        provideHttpClient(withInterceptorsFromDi()),
         importProvidersFrom(
             StoreModule.forRoot(
                 AppReducers,


### PR DESCRIPTION
# Fixes #11

Removed deprecated dependency HttpClientModule not recommended for Angular 15+ projects 