### PR TITLE
#17 | show user balances right after login

### DIFF
--- a/src/app/pages/wallet/wallet.component.html
+++ b/src/app/pages/wallet/wallet.component.html
@@ -1,5 +1,5 @@
-<div *ngIf="actor; else noSession">
-    <h2>{{ actor }}</h2>
+<div *ngIf="sessionService.currentSession?.actor; else noSession">
+    <h2>{{ sessionService.currentSession.actor }}</h2>
 
     <div *ngIf="loading; else balanceList">
         <p>[ Loading... ]</p>

--- a/src/app/pages/wallet/wallet.component.html
+++ b/src/app/pages/wallet/wallet.component.html
@@ -6,13 +6,11 @@
     </div>
 
     <ng-template #balanceList>
-        <div *ngIf="balances.length > 0">
             <div *ngFor="let balance of balances">
                 <div class="balanceDisplay">
-                    {{ balance.amount }} {{ balance.token.symbol }}
+                    {{ balance.amount.formatted }} {{ balance.token.symbol }}
                 </div>
             </div>
-        </div>
     </ng-template>
 
     <br>

--- a/src/app/pages/wallet/wallet.component.html
+++ b/src/app/pages/wallet/wallet.component.html
@@ -1,5 +1,5 @@
-<div *ngIf="sessionService.currentSession?.actor; else noSession">
-    <h2>{{ sessionService.currentSession.actor }}</h2>
+<div *ngIf="actor; else noSession">
+    <h2>{{ actor }}</h2>
 
     <div *ngIf="loading; else balanceList">
         <p>[ Loading... ]</p>

--- a/src/app/pages/wallet/wallet.component.html
+++ b/src/app/pages/wallet/wallet.component.html
@@ -6,17 +6,17 @@
     </div>
 
     <ng-template #balanceList>
-        <div *ngIf="balances | keyvalue as tokenBalances">
-            <div *ngFor="let balance of tokenBalances">
-                <div class="token-balance">
-                    {{ balance.value }}
+        <div *ngIf="balances.length > 0">
+            <div *ngFor="let balance of balances">
+                <div class="balanceDisplay">
+                    {{ balance.amount }} {{ balance.token.symbol }}
                 </div>
             </div>
         </div>
     </ng-template>
+
     <br>
     <button class="btn" (click)="refreshBalances()">Refresh Balances</button>
-
 </div>
 
 <ng-template #noSession>

--- a/src/app/pages/wallet/wallet.component.ts
+++ b/src/app/pages/wallet/wallet.component.ts
@@ -54,7 +54,8 @@ export class WalletComponent implements OnInit, OnDestroy {
                 let balanceData = await this.tokenBalanceService.getTokenBalance(
                     this.sessionService.currentSession?.client.v1.chain, 
                     token, 
-                    account
+                    account,
+                    false
                 );
                 if(balanceData){
                     this.balances.push(balanceData);

--- a/src/app/pages/wallet/wallet.component.ts
+++ b/src/app/pages/wallet/wallet.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SessionService } from '@app/services/session-kit.service';
 import { TokenBalanceService } from '@app/services/token-balance.service';
+import { TokenListService } from '@app/services/token-list.service';
+import { Token } from 'src/types';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -13,34 +15,57 @@ import { Subscription } from 'rxjs';
 })
 export class WalletComponent implements OnInit, OnDestroy {
     actor: string | undefined;
-    balances: { [symbol: string]: string } = {};
-    loading = false;  // Track loading state
+    tokens: Token[] = [];
+    balances: { amount: number; token: Token }[] = [];
+    loading = false;  
     private sessionSubscription!: Subscription;
+    private tokenSubscription!: Subscription;
 
     constructor(
         private sessionService: SessionService,
-        private balanceService: TokenBalanceService
+        private tokenBalanceService: TokenBalanceService,
+        private tokenListService: TokenListService
     ) {}
 
     ngOnInit() {
         this.sessionSubscription = this.sessionService.session$.subscribe(async session => {
             this.actor = session?.actor;
             if (this.actor) {
-                await this.loadBalances(this.actor);
+                this.loadTokenList();
             }
         });
     }
 
-    async loadBalances(account: string) {
-        this.loading = true;  // Start loading
-        try {
-            this.balances = await this.balanceService.getAllBalances(account);
-        } catch (error) {
-            console.error('Error loading balances:', error);
-        } finally {
-            this.loading = false;  // Stop loading
-        }
+    private loadTokenList() {
+        this.tokenSubscription = this.tokenListService.getTokens().subscribe(tokens => {
+            this.tokens = tokens;
+            if (this.actor) {
+                this.loadBalances(this.actor);
+            }
+        });
     }
+
+    private async loadBalances(account: string) {
+        this.loading = true;  
+        this.balances = []; 
+    
+        for (const token of this.tokens) {
+            try {
+                let balanceData = await this.tokenBalanceService.getTokenBalance(
+                    this.sessionService.currentSession?.client.v1.chain, 
+                    token, 
+                    account
+                );
+                if(balanceData){
+                    this.balances.push(balanceData);
+                }
+            } catch (error) {
+                console.error(`Error fetching balance for ${token.symbol}:`, error);
+            }
+        }
+    
+        this.loading = false;
+    }    
 
     async refreshBalances() {
         if (this.actor) {
@@ -49,8 +74,7 @@ export class WalletComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
-        if (this.sessionSubscription) {
-            this.sessionSubscription.unsubscribe();
-        }
+        if (this.sessionSubscription) this.sessionSubscription.unsubscribe();
+        if (this.tokenSubscription) this.tokenSubscription.unsubscribe();
     }
 }

--- a/src/app/pages/wallet/wallet.component.ts
+++ b/src/app/pages/wallet/wallet.component.ts
@@ -16,7 +16,7 @@ import { Subscription } from 'rxjs';
 export class WalletComponent implements OnInit, OnDestroy {
     actor: string | undefined;
     tokens: Token[] = [];
-    balances: { amount: number; token: Token }[] = [];
+    balances: { amount: { raw: number; formatted: string }; token: Token }[] = [];
     loading = false;  
     private sessionSubscription!: Subscription;
     private tokenSubscription!: Subscription;

--- a/src/app/pages/wallet/wallet.component.ts
+++ b/src/app/pages/wallet/wallet.component.ts
@@ -1,10 +1,9 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { SessionService } from '@app/services/session-kit.service';
 import { TokenBalanceService } from '@app/services/token-balance.service';
-import { TokenListService } from '@app/services/token-list.service';
-import { Token } from 'src/types';
+import { SessionService } from '@app/services/session-kit.service';
 import { Subscription } from 'rxjs';
+import { Balance } from 'src/types';
 
 @Component({
     selector: 'app-wallet',
@@ -14,68 +13,29 @@ import { Subscription } from 'rxjs';
     styleUrls: ['./wallet.component.scss'],
 })
 export class WalletComponent implements OnInit, OnDestroy {
-    tokens: Token[] = [];
-    balances: { amount: { raw: number; formatted: string }; token: Token }[] = [];
-    loading = false;  
-    private sessionSubscription!: Subscription;
-    private tokenSubscription!: Subscription;
+    balances: Balance[] = [];
+    loading = false;  // Add loading state
+    private balanceSubscription!: Subscription;
 
     constructor(
-        public sessionService: SessionService, // Changed from private to public
-        private tokenBalanceService: TokenBalanceService,
-        private tokenListService: TokenListService
+        public sessionService: SessionService, // Set sessionService as public
+        private tokenBalanceService: TokenBalanceService
     ) {}
 
     ngOnInit() {
-        this.sessionSubscription = this.sessionService.session$.subscribe(async session => {
-            if (session?.actor) {
-                this.loadTokenList();
-            }
-        });
-    }
-
-    private loadTokenList() {
-        this.tokenSubscription = this.tokenListService.getTokens().subscribe(tokens => {
-            this.tokens = tokens;
-            if (this.sessionService.currentSession?.actor) {
-                this.loadBalances();
-            }
-        });
-    }
-
-    private async loadBalances() {
-        const account = this.sessionService.currentSession?.actor;
-        if (!account) return;
-
         this.loading = true;
-        this.balances = [];
+        this.balanceSubscription = this.tokenBalanceService.getAllBalances().subscribe(balances => {
+            this.balances = balances;
+            this.loading = false;
+        });
+    }
 
-        for (const token of this.tokens) {
-            try {
-                const balanceData = await this.tokenBalanceService.getTokenBalance(
-                    this.sessionService.currentSession?.client.v1.chain, 
-                    token, 
-                    account
-                );
-                if (balanceData) {
-                    this.balances.push(balanceData);
-                }
-            } catch (error) {
-                console.error(`Error fetching balance for ${token.symbol}:`, error);
-            }
-        }
-
-        this.loading = false;
-    }    
-
-    async refreshBalances() {
-        if (this.sessionService.currentSession?.actor) {
-            await this.loadBalances();
-        }
+    refreshBalances() {
+        this.loading = true;
+        this.tokenBalanceService.refreshAllBalances();
     }
 
     ngOnDestroy() {
-        if (this.sessionSubscription) this.sessionSubscription.unsubscribe();
-        if (this.tokenSubscription) this.tokenSubscription.unsubscribe();
+        if (this.balanceSubscription) this.balanceSubscription.unsubscribe();
     }
 }

--- a/src/app/pages/wallet/wallet.component.ts
+++ b/src/app/pages/wallet/wallet.component.ts
@@ -18,9 +18,13 @@ export class WalletComponent implements OnInit, OnDestroy {
     private balanceSubscription!: Subscription;
 
     constructor(
-        public sessionService: SessionService, // Set sessionService as public
+        private sessionService: SessionService,
         private tokenBalanceService: TokenBalanceService
     ) {}
+
+    get actor(): string | undefined {
+        return this.sessionService.currentSession?.actor;
+    }
 
     ngOnInit() {
         this.loading = true;

--- a/src/app/services/session-kit.service.ts
+++ b/src/app/services/session-kit.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
+import { Router } from '@angular/router';
 import { SessionKit } from '@wharfkit/session';
 import { WebRenderer } from '@wharfkit/web-renderer';
 import { WalletPluginAnchor } from '@wharfkit/wallet-plugin-anchor';
@@ -15,7 +16,9 @@ export class SessionService {
     private sessionSubject = new BehaviorSubject<any>(undefined);
     session$: Observable<any> = this.sessionSubject.asObservable();
 
-    constructor() {
+    constructor(
+        private router: Router // inject the Router
+    ) {
         this.sessionKit = new SessionKit({
             appName: 'session-connect',
             chains: [
@@ -43,6 +46,7 @@ export class SessionService {
             const { session } = await this.sessionKit.login();
             this.sessionSubject.next(session);  // Emit the new session
             console.log('Login successful:', session);
+            this.router.navigate(['/wallet']);
             return session;
         } catch (error) {
             console.error('Login failed:', error);

--- a/src/app/services/token-balance.service.ts
+++ b/src/app/services/token-balance.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
 import { SessionService } from '@app/services/session-kit.service';
 import { Token } from 'src/types';
 
@@ -7,95 +6,32 @@ import { Token } from 'src/types';
     providedIn: 'root'
 })
 export class TokenBalanceService {
-    private tokens: Token[] = [];
+    constructor(private sessionService: SessionService) {}
 
-    constructor(
-        private sessionService: SessionService,
-        private http: HttpClient
-    ) {
-        this.loadTokenList();
-    }
-
-    // Load token list from JSON file
-    private loadTokenList() {
-        this.http.get<Token[]>('assets/tokens_mainnet.json').subscribe({
-            next: tokens => (this.tokens = tokens),
-            error: err => console.error('Error loading token list:', err)
-        });
-    }
-
-    // Fetch all token balances for the current account
-    async getAllBalances(account: string): Promise<{ [symbol: string]: string }> {
-        const session = this.sessionService.currentSession;
-        if (!session) {
-            throw new Error('No active session. Please log in first.');
-        }
-
-        const balances: { [symbol: string]: string } = {};
-
-        for (const token of this.tokens) {
-            try {
-                const balance = await this.getBalance(session.client.v1.chain, token, account);
-                balances[token.symbol] = balance;
-            } catch (error) {
-                console.error(`Error fetching balance for ${token.symbol}:`, error);
-                balances[token.symbol] = this.formatBalance(0, token);
-            }
-        }
-        console.log('Raw balances:', balances);
-
-        const filteredBalances = this.filter_zero_balance(balances);
-        return filteredBalances;
-    }
-
-    // ✅ Function to filter out tokens with zero balance, keeping TLOS always
-    private filter_zero_balance(balances: { [symbol: string]: string }): { [symbol: string]: string } {
-        const filteredBalances: { [symbol: string]: string } = {};
-
-        for (const [symbol, balance] of Object.entries(balances)) {
-            const numericBalance = parseFloat(balance.split(' ')[0]); // Extract numeric part
-
-            if (symbol === 'TLOS' || numericBalance > 0) {
-                filteredBalances[symbol] = balance;
-            }
-        }
-
-        return filteredBalances;
-    }
-
-    // Fetch balance for a single token
-    private async getBalance(client: any, token: Token, account: string): Promise<string> {
+    async getTokenBalance(client: any, token: Token, account: string): Promise<{ amount: number; token: Token } | undefined> {
         try {
             const result = await client.get_currency_balance(token.account, account, token.symbol);
-            console.log(result)
-            // Check if result is an array with at least one item
+            console.log(`Balance result for ${token.symbol}:`, result);
+    
+            // Ensure result is an array
             if (Array.isArray(result) && result.length > 0) {
                 const balanceEntry = result[0];
     
-                // If it's a string, return as-is
-                if (typeof balanceEntry === 'string') {
-                    return balanceEntry;
+                // Extract balance if it's the expected object format
+                if (typeof balanceEntry === 'object' && balanceEntry.units?.value?.words?.length > 0) {
+                    const rawBalance = balanceEntry.units.value.words[0];
+                    console.log(`Extracted raw balance for ${token.symbol}:`, rawBalance);
+                    return { amount: rawBalance, token };
                 }
     
-                // If it's an object, extract numeric value (adjust this based on actual API response structure)
-                if (typeof balanceEntry === 'object' && balanceEntry.value) {
-                    const balance = balanceEntry.value.toString(); // Convert to string safely
-                    return this.formatBalance(balance, token);
-                }
+                console.warn(`Unexpected balance format for ${token.symbol}:`, balanceEntry);
             }
     
-            return this.formatBalance(0, token); // Default to zero balance
+            console.log(`No balance found for ${token.symbol}, fallback: 0`);
+            return { amount: 0, token };
         } catch (error) {
             console.error(`Error fetching balance for ${token.symbol}:`, error);
-            return this.formatBalance(0, token);
+            return undefined;
         }
-    }
-    
-    
-
-    // Format balance using token precision
-    private formatBalance(amount: number | string, token: Token): string {
-        const precision = token.precision;
-        return `${Number(amount).toFixed(precision)} ${token.symbol}`;
     }
 }

--- a/src/app/services/token-balance.service.ts
+++ b/src/app/services/token-balance.service.ts
@@ -8,30 +8,36 @@ import { Token } from 'src/types';
 export class TokenBalanceService {
     constructor(private sessionService: SessionService) {}
 
-    async getTokenBalance(client: any, token: Token, account: string): Promise<{ amount: number; token: Token } | undefined> {
+    async getTokenBalance(client: any, token: Token, account: string): Promise<{ amount: { raw: number; formatted: string }; token: Token } | undefined> {
         try {
             const result = await client.get_currency_balance(token.account, account, token.symbol);
             console.log(`Balance result for ${token.symbol}:`, result);
     
-            // Ensure result is an array
+            let rawAmount = 0;
             if (Array.isArray(result) && result.length > 0) {
                 const balanceEntry = result[0];
     
-                // Extract balance if it's the expected object format
                 if (typeof balanceEntry === 'object' && balanceEntry.units?.value?.words?.length > 0) {
-                    const rawBalance = balanceEntry.units.value.words[0];
-                    console.log(`Extracted raw balance for ${token.symbol}:`, rawBalance);
-                    return { amount: rawBalance, token };
+                    rawAmount = balanceEntry.units.value.words[0];
+                    console.log(`Extracted raw balance for ${token.symbol}:`, rawAmount);
+                } else {
+                    console.warn(`Unexpected balance format for ${token.symbol}:`, balanceEntry);
                 }
-    
-                console.warn(`Unexpected balance format for ${token.symbol}:`, balanceEntry);
+            } else {
+                console.log(`No balance found for ${token.symbol}, fallback: 0`);
             }
-    
-            console.log(`No balance found for ${token.symbol}, fallback: 0`);
-            return { amount: 0, token };
+
+            const formattedAmount = this.formatBalance(rawAmount, token);
+            return { amount: { raw: rawAmount, formatted: formattedAmount }, token };
         } catch (error) {
             console.error(`Error fetching balance for ${token.symbol}:`, error);
             return undefined;
         }
+    }
+
+    formatBalance(rawAmount: number, token: Token): string {
+        const precision = token.precision;
+        const factor = Math.pow(10, precision);
+        return (rawAmount / factor).toFixed(precision);
     }
 }

--- a/src/app/services/token-balance.service.ts
+++ b/src/app/services/token-balance.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { SessionService } from '@app/services/session-kit.service';
 import { Token } from 'src/types';
 
 @Injectable({
@@ -8,7 +7,7 @@ import { Token } from 'src/types';
 export class TokenBalanceService {
     constructor() {}
 
-    async getTokenBalance(client: any, token: Token, account: string, get_zero_balance: boolean): Promise<{ amount: { raw: number; formatted: string }; token: Token } | undefined> {
+    async getTokenBalance(client: any, token: Token, account: string, get_zero_balance: boolean = false): Promise<{ amount: { raw: number; formatted: string }; token: Token } | undefined> {
         try {
             const result = await client.get_currency_balance(token.account, account, token.symbol);
             console.log(`Balance result for ${token.symbol}:`, result);

--- a/src/app/services/token-list.service.ts
+++ b/src/app/services/token-list.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject } from 'rxjs';
+import { Token } from 'src/types';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class TokenListService {
+    private tokens$ = new BehaviorSubject<Token[]>([]);
+
+    constructor(private http: HttpClient) {
+        this.loadTokenList();
+    }
+
+    private loadTokenList(): void {
+        this.http.get<Token[]>('assets/tokens_mainnet.json').subscribe({
+            next: tokens => {
+                this.tokens$.next(tokens);
+                console.log('Loaded Tokens:', tokens);
+            },
+            error: err => console.error('Error loading token list:', err),
+        });
+    }
+
+    getTokens() {
+        return this.tokens$.asObservable(); // Expose as observable for components
+    }
+
+    getTokensValue() {
+        return this.tokens$.getValue(); // Get latest value without subscribing
+    }
+}

--- a/src/types/Balance.ts
+++ b/src/types/Balance.ts
@@ -1,0 +1,9 @@
+import { Token } from "./Token";
+
+export interface Balance {
+    amount: {
+        raw: number;
+        formatted: string;
+    };
+    token: Token;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './Token';
+export * from './Balance'
 // other exports


### PR DESCRIPTION
# Fix #17 

## Description

Refactored the way of getting and managing the user Balances.
token-balance.service is in charge not only of providing the logic, but also stores balances$ as a Behavior Subject. This way balance management is centralized, and Wallet page is simplified.

![2025-02-16-214127_293x252_scrot](https://github.com/user-attachments/assets/e1a5053d-c69b-4a91-9bc9-e140f4ccbb94)
