### PR TITLE
30 sidemenu for mobile

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -9,6 +9,5 @@
     justify-content: left;
     align-items: center;
     /* Creates a fading shadow effect at the top */
-    background: linear-gradient(rgba(0, 0, 0, 0.06) 0px, rgba(0, 0, 0, 0) 50px);
-    min-height: 800px;
+    background: linear-gradient(rgba(0, 0, 0, 0.05) 0px, rgba(0, 0, 0, 0) 50px);
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,7 +14,7 @@ import { SideContainerComponent } from '@app/components/base-components/side-con
     ],
     template: `
         <app-nav-bar></app-nav-bar>
-        <app-side-container id="mobile-side-menu" side="left">
+        <app-side-container id="mobile-side-menu" side="right">
             <h2>Side Menu</h2>
             <p>Navigation links or other content can go here.</p>
         </app-side-container>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,7 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { NavBarComponent } from './components/nav-bar/nav-bar.component';
-import { SideContainerComponent } from '@app/components/base-components/side-container/side-container.component';
-
+import { NavBarComponent } from '@app/components/nav-bar/nav-bar.component';
+import { SideMenuMobileComponent } from '@app/components/side-menu-mobile/side-menu-mobile.component';
 
 @Component({
     selector: 'app-root',
@@ -10,17 +9,15 @@ import { SideContainerComponent } from '@app/components/base-components/side-con
     imports: [
         RouterOutlet,
         NavBarComponent,
-        SideContainerComponent
+        SideMenuMobileComponent
     ],
     template: `
         <app-nav-bar></app-nav-bar>
-        <app-side-container id="mobile-side-menu" side="right">
-            <h2>Side Menu</h2>
-            <p>Navigation links or other content can go here.</p>
-        </app-side-container>
         <div class="view">
             <router-outlet></router-outlet>
         </div>
+        <app-side-menu-mobile></app-side-menu-mobile>
+
     `,
     styleUrls: ['./app.component.scss']
 })

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,13 +1,23 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { NavBarComponent } from './components/nav-bar/nav-bar.component';
+import { SideContainerComponent } from '@app/components/base-components/side-container/side-container.component';
+
 
 @Component({
     selector: 'app-root',
     standalone: true,
-    imports: [RouterOutlet, NavBarComponent],
+    imports: [
+        RouterOutlet,
+        NavBarComponent,
+        SideContainerComponent
+    ],
     template: `
         <app-nav-bar></app-nav-bar>
+        <app-side-container id="mobile-side-menu" side="left">
+            <h2>Side Menu</h2>
+            <p>Navigation links or other content can go here.</p>
+        </app-side-container>
         <div class="view">
             <router-outlet></router-outlet>
         </div>

--- a/src/app/components/base-components/drop-down/drop-down.component.scss
+++ b/src/app/components/base-components/drop-down/drop-down.component.scss
@@ -6,6 +6,7 @@
         display: flex;
         flex-direction: column;
         position: absolute;
+        gap: 12px;
         top: 50px;
         right: 0px;
         background-color: var(--c-background-0);

--- a/src/app/components/base-components/side-container/side-container.component.html
+++ b/src/app/components/base-components/side-container/side-container.component.html
@@ -1,0 +1,5 @@
+<div class="side-container-overlay" *ngIf="isOpen" (click)="close()"></div>
+
+<div class="side-container" [class.open]="isOpen" [class.left]="side === 'left'" [class.right]="side === 'right'">
+    <ng-content></ng-content>
+</div>

--- a/src/app/components/base-components/side-container/side-container.component.html
+++ b/src/app/components/base-components/side-container/side-container.component.html
@@ -1,4 +1,4 @@
-<div class="side-container-overlay" *ngIf="isOpen" (click)="close()"></div>
+<div class="side-container-overlay" (click)="close()" [class.open]="isOpen"></div>
 
 <div class="side-container" [class.open]="isOpen" [class.left]="side === 'left'" [class.right]="side === 'right'">
     <ng-content></ng-content>

--- a/src/app/components/base-components/side-container/side-container.component.scss
+++ b/src/app/components/base-components/side-container/side-container.component.scss
@@ -4,14 +4,14 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(0, 0, 0, 0.9);
-    opacity: 0;
-    transition: opacity 0.3s ease-in-out;
     pointer-events: none;
-    z-index: 1999;
+    background: rgba(0, 0, 0, 0);
+    transition: 0.2s ease-out;
+    z-index: 99;
 
     &.open {
-        opacity: 1;
+        background: rgba(0, 0, 0, 0.3);
+        backdrop-filter: blur(3px);
         pointer-events: auto;
     }
 }
@@ -19,21 +19,25 @@
 .side-container {
     position: fixed;
     top: 0;
-    width: 80%;
+    width: 60%;
     height: 100%;
-    background: var(--c-background-1);
-    box-shadow: var(--c-shadow-2);
-    transition: transform 0.3s ease-in-out;
+    background: var(--c-background-0);
+    border: 1px solid var(--c-background-3);
+    padding: 20px 40px;
+    transition: transform 0.5s ease-out;
     z-index: 100;
+
 
     &.right {
         right: 0;
         transform: translateX(100%);
+        border-radius: 20px 0px 0px 0px;
     }
 
     &.left {
         left: 0;
         transform: translateX(-100%);
+        border-radius: 0px 20px 0px 0px;
     }
 
     &.open {

--- a/src/app/components/base-components/side-container/side-container.component.scss
+++ b/src/app/components/base-components/side-container/side-container.component.scss
@@ -23,7 +23,7 @@
     height: 100%;
     background: var(--c-background-0);
     border: 1px solid var(--c-background-3);
-    padding: 20px 40px;
+    padding: 10px 10px;
     transition: transform 0.5s ease-out;
     z-index: 100;
 

--- a/src/app/components/base-components/side-container/side-container.component.scss
+++ b/src/app/components/base-components/side-container/side-container.component.scss
@@ -1,0 +1,42 @@
+.side-container-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.9);
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+    pointer-events: none;
+    z-index: 1999;
+
+    &.open {
+        opacity: 1;
+        pointer-events: auto;
+    }
+}
+
+.side-container {
+    position: fixed;
+    top: 0;
+    width: 80%;
+    height: 100%;
+    background: var(--c-background-1);
+    box-shadow: var(--c-shadow-2);
+    transition: transform 0.3s ease-in-out;
+    z-index: 100;
+
+    &.right {
+        right: 0;
+        transform: translateX(100%);
+    }
+
+    &.left {
+        left: 0;
+        transform: translateX(-100%);
+    }
+
+    &.open {
+        transform: translateX(0);
+    }
+}

--- a/src/app/components/base-components/side-container/side-container.component.ts
+++ b/src/app/components/base-components/side-container/side-container.component.ts
@@ -1,0 +1,36 @@
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { SideContainerService } from './side-container.service';
+
+@Component({
+    selector: 'app-side-container',
+    standalone: true,
+    imports: [CommonModule],
+    templateUrl: './side-container.component.html',
+    styleUrls: ['./side-container.component.scss']
+})
+export class SideContainerComponent implements OnInit, OnDestroy {
+    @Input() id!: string;
+    @Input() side: 'left' | 'right' = 'right';
+    isOpen = false;
+    private subscription!: Subscription;
+
+    constructor(private sideContainerService: SideContainerService) {}
+
+    ngOnInit() {
+        this.subscription = this.sideContainerService.state$.subscribe(state => {
+            this.isOpen = !!state[this.id];
+        });
+    }
+
+    close() {
+        this.sideContainerService.close(this.id);
+    }
+
+    ngOnDestroy() {
+        if (this.subscription) {
+            this.subscription.unsubscribe();
+        }
+    }
+}

--- a/src/app/components/base-components/side-container/side-container.service.ts
+++ b/src/app/components/base-components/side-container/side-container.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class SideContainerService {
+    private state = new BehaviorSubject<Record<string, boolean>>({});
+    state$ = this.state.asObservable();
+
+    open(id: string) {
+        this.state.next({ ...this.state.getValue(), [id]: true });
+    }
+
+    close(id: string) {
+        this.state.next({ ...this.state.getValue(), [id]: false });
+    }
+
+    toggle(id: string) {
+        const currentState = this.state.getValue();
+        this.state.next({ ...currentState, [id]: !currentState[id] });
+    }
+}

--- a/src/app/components/login/login.component.scss
+++ b/src/app/components/login/login.component.scss
@@ -1,8 +1,8 @@
 hr.wide {
-    width: calc(100% - 20px);
-    margin: 10px 10px;
+    width: 100%;
     padding: 0px;
+    margin: 0px;
     border: 0;
-    background-color: var(--c-accent-0);
+    background-color: var(--c-background-4);
     height: 1px;
 }

--- a/src/app/components/nav-bar/nav-bar.component.html
+++ b/src/app/components/nav-bar/nav-bar.component.html
@@ -26,12 +26,14 @@
         </div>
 
         <div class="row">
-            <lucide-icon
-                [img]="isDarkTheme ? SunIcon : MoonIcon"
-                class="icon"
-                (click)="toggleTheme()"
-                style="margin-top: 6px;"
-            ></lucide-icon>
+            <a>
+                <lucide-icon
+                    [img]="isDarkTheme ? SunIcon : MoonIcon"
+                    class="icon"
+                    (click)="toggleTheme()"
+                    style="margin-top: 6px;"
+                ></lucide-icon>
+            </a>
             <app-login></app-login>
         </div>
     </nav>
@@ -40,10 +42,10 @@
 <!-- Mobile Navbar | whidth < 599px -->
 <ng-template #mobileNav>
     <nav class="mobile-nav">
-        <lucide-icon [img]="QrIcon" class="icon"></lucide-icon>
+        <a><lucide-icon [img]="QrIcon" class="icon"></lucide-icon></a>
 
         <app-login></app-login>
 
-        <lucide-icon [img]="MenuIcon" class="icon" (click)="toggleMobileSideMenu()"></lucide-icon>
+        <a (click)="toggleMobileSideMenu()" class=""><lucide-icon [img]="MenuIcon" class="icon"></lucide-icon></a>
     </nav>
 </ng-template>

--- a/src/app/components/nav-bar/nav-bar.component.html
+++ b/src/app/components/nav-bar/nav-bar.component.html
@@ -44,6 +44,6 @@
 
         <app-login></app-login>
 
-        <lucide-icon [img]="MenuIcon" class="icon"></lucide-icon>
+        <lucide-icon [img]="MenuIcon" class="icon" (click)="toggleMobileSideMenu()"></lucide-icon>
     </nav>
 </ng-template>

--- a/src/app/components/nav-bar/nav-bar.component.ts
+++ b/src/app/components/nav-bar/nav-bar.component.ts
@@ -9,6 +9,7 @@ import { Subject, takeUntil } from 'rxjs';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { LucideAngularModule, Menu, ScanQrCode, Sun, Moon} from 'lucide-angular'
 import { BREAKPOINT } from 'src/types';
+import { SideContainerService } from '@app/components/base-components/side-container/side-container.service';
 
 @Component({
     selector: 'app-nav-bar',
@@ -37,7 +38,8 @@ export class NavBarComponent implements OnInit, OnDestroy {
     constructor(
         private store: Store<AppState>,
         @Inject(DOCUMENT) private document: Document,
-        private breakpointObserver: BreakpointObserver
+        private breakpointObserver: BreakpointObserver,
+        private sideContainerService: SideContainerService,
     ) {}
 
     ngOnInit() {
@@ -60,6 +62,10 @@ export class NavBarComponent implements OnInit, OnDestroy {
         this.isDarkTheme
             ? this.store.dispatch(user.actions.setLight())
             : this.store.dispatch(user.actions.setDark());
+    }
+
+    toggleMobileSideMenu() {
+        this.sideContainerService.toggle('mobile-side-menu');
     }
 
     ngOnDestroy() {

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.html
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.html
@@ -1,0 +1,4 @@
+<app-side-container id="mobile-side-menu" side="right">
+    <h2>Side Menu</h2>
+    <p>Navigation links or other content can go here.</p>
+</app-side-container>

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.html
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.html
@@ -1,4 +1,21 @@
 <app-side-container id="mobile-side-menu" side="right">
-    <h2>Side Menu</h2>
-    <p>Navigation links or other content can go here.</p>
+    <p class="header">Mobile side-menu head</p>
+    <hr class="wide">
+    <a class="option" (click)="close()">
+        <lucide-icon [img]="WalletIcon"></lucide-icon>
+        <p>option A</p>
+    </a>
+    <a class="option" (click)="close()">
+        <lucide-icon [img]="UsersIcon"></lucide-icon>
+        <p>option B</p>
+    </a>
+    <a class="option" (click)="close()">
+        <lucide-icon [img]="OmegaIcon"></lucide-icon>
+        <p>option C</p>
+    </a>
+    <hr class="wide">
+    <a class="option" (click)="close()">
+        <lucide-icon [img]="LogoutIcon"></lucide-icon>
+        <p>Logout</p>
+    </a>
 </app-side-container>

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.scss
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.scss
@@ -1,0 +1,30 @@
+.header{
+    color: var(--c-foreground-2);
+    border: 1px solid var(--c-background-1);
+    border-radius: 10px;
+    padding: 30px 20px;
+    margin: 0px 0px 10px 0px;
+}
+
+.option{
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--c-foreground-2);
+    border: 1px solid var(--c-background-0);
+    border-radius: 10px;
+    padding: 0px 20px;
+
+    &:hover{
+        background-color: var(--c-background-1);
+        color: var(--c-foreground-0);
+    }
+}
+
+hr.wide {
+    width: 100%;
+    padding: 0px;
+    border: 0;
+    background-color: var(--c-background-4);
+    height: 1px;
+}

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { SideContainerComponent } from '@app/components/base-components/side-container/side-container.component';
+
+@Component({
+  selector: 'app-side-menu-mobile',
+  imports: [SideContainerComponent],
+  templateUrl: './side-menu-mobile.component.html',
+  styleUrl: './side-menu-mobile.component.scss'
+})
+export class SideMenuMobileComponent {
+
+}

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
@@ -1,12 +1,26 @@
 import { Component } from '@angular/core';
 import { SideContainerComponent } from '@app/components/base-components/side-container/side-container.component';
+import { LucideAngularModule, Omega, Users, Wallet, LogOut } from 'lucide-angular';
+import { SideContainerService } from '@app/components/base-components/side-container/side-container.service';
 
 @Component({
-  selector: 'app-side-menu-mobile',
-  imports: [SideContainerComponent],
-  templateUrl: './side-menu-mobile.component.html',
-  styleUrl: './side-menu-mobile.component.scss'
+    selector: 'app-side-menu-mobile',
+    imports: [SideContainerComponent, LucideAngularModule],
+    templateUrl: './side-menu-mobile.component.html',
+    styleUrl: './side-menu-mobile.component.scss'
 })
 export class SideMenuMobileComponent {
+    readonly OmegaIcon = Omega
+    readonly UsersIcon = Users
+    readonly WalletIcon = Wallet
+    readonly LogoutIcon = LogOut
+
+    constructor(
+        private sideContainerService: SideContainerService,
+    ) {}
+
+    close() {
+        this.sideContainerService.close('mobile-side-menu');
+    }
 
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -71,10 +71,12 @@ body.light-theme {
 }
 
 svg.icon {
-    color: var(--c-foreground-2);
-    stroke-width: 1.8;
+    stroke-width: 1.6;
     width: 26px;
     height: 26px;
+}
+body.light-theme svg.icon {
+    stroke-width: 1.4;
 }
 
 /* Global base styles here */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -89,7 +89,6 @@ body {
 
 a {
     text-decoration: none;
-    margin: 10px;
     color: var(--c-foreground-2);
     cursor: pointer;
 


### PR DESCRIPTION
# Fix #30 

This is a sub issue from #26 

## Description

- New reusable `base-component/side-container/`: In charge of defining and managing a container that slides in from a side(left/right) when opened.

- New `components/side-menu-mobile`: Based on the reusable side-container, instantiated in app.component, and accessed though the hamburger icon in the mobile nav-bar.

 
![2025-03-17-190637_516x934_scrot](https://github.com/user-attachments/assets/505d706c-5ffb-492c-94df-f4578abf0557)

- Simple style adjustments 