### PR TITLE
#31 | desktop for dex mobile for payments wallet

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -18,12 +18,11 @@ import { RedirectService } from '@app/services/redirect.services';
             <router-outlet></router-outlet>
         </div>
         <app-side-menu-mobile></app-side-menu-mobile>
-
     `,
     styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
     title = 'my-angular-app';
 
-    constructor(private authRedirectService: RedirectService) {} // Instantiates service
+    constructor(private redirectService: RedirectService) {} // Instantiates service
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { NavBarComponent } from '@app/components/nav-bar/nav-bar.component';
 import { SideMenuMobileComponent } from '@app/components/side-menu-mobile/side-menu-mobile.component';
+import { RedirectService } from '@app/services/redirect.services';
 
 @Component({
     selector: 'app-root',
@@ -23,4 +24,6 @@ import { SideMenuMobileComponent } from '@app/components/side-menu-mobile/side-m
 })
 export class AppComponent {
     title = 'my-angular-app';
+
+    constructor(private authRedirectService: RedirectService) {} // Instantiates service
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { ExploreComponent } from '@app/pages/explore/explore.component';
 import { PoolComponent } from '@app/pages/pool/pool.component';
 import { WalletComponent } from './pages/wallet/wallet.component';
 import { PreferencesComponent } from './pages/preferences/preferences.component';
+import { AccountsComponent } from './pages/accounts/accounts.component';
 
 export const routes: Routes = [
     // Navigate to 'home' component by default (empty path)
@@ -15,4 +16,5 @@ export const routes: Routes = [
     { path: 'pool', component: PoolComponent },
     { path: 'wallet', component: WalletComponent },
     { path: 'preferences', component: PreferencesComponent},
+    { path: 'accounts', component: AccountsComponent},
 ];

--- a/src/app/components/base-components/drop-down/drop-down.component.html
+++ b/src/app/components/base-components/drop-down/drop-down.component.html
@@ -1,12 +1,14 @@
 <div class="dropdown">
-    <div class="btn" (click)="toggleDropdown()">
-        {{ buttonText }}
+    <!-- Button Slot -->
+    <div (click)="toggleDropdown()">
+        <ng-content select="[dropdown-button]"></ng-content>
     </div>
 
-    <!-- Overlay that appears when the dropdown is open -->
+    <!-- Overlay -->
     <div *ngIf="isOpen" class="overlay" (click)="closeDropdown()"></div>
 
-    <div *ngIf="isOpen" class="dropdown-content">
-        <ng-content></ng-content>
+    <!-- Dropdown Body Slot -->
+    <div *ngIf="isOpen" class="dropdown-body">
+        <ng-content select="[dropdown-body]"></ng-content>
     </div>
 </div>

--- a/src/app/components/base-components/drop-down/drop-down.component.scss
+++ b/src/app/components/base-components/drop-down/drop-down.component.scss
@@ -2,11 +2,8 @@
     position: relative;
     display: inline-block;
 
-    .dropdown-content {
-        display: flex;
-        flex-direction: column;
+    .dropdown-body {
         position: absolute;
-        gap: 12px;
         top: 50px;
         right: 0px;
         background-color: var(--c-background-0);

--- a/src/app/components/base-components/drop-down/drop-down.component.ts
+++ b/src/app/components/base-components/drop-down/drop-down.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
     selector: 'app-drop-down',
@@ -9,8 +9,6 @@ import { Component, Input } from '@angular/core';
     styleUrls: ['./drop-down.component.scss']
 })
 export class DropDownComponent {
-    @Input() buttonText: string = 'buttonText';  // Default text
-
     isOpen = false;
 
     toggleDropdown() {

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -12,6 +12,7 @@
             <!-- Dropdown Body -->
             <div dropdown-body class="body">
                 <a routerLink="/wallet">Wallet</a>
+                <a routerLink="/accounts">Accounts</a>
                 <a routerLink="/preferences">Preferences</a>
                 <hr class="wide">
                 <a (click)="logout()">Logout</a>

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -2,11 +2,20 @@
     <button class="btn" (click)="login()" *ngIf="!(sessionService.session$ | async)">Login</button>
 
     <div *ngIf="(sessionService.session$ | async) as session">
-        <app-drop-down [buttonText]="session.actor">
-            <a routerLink="/wallet"> Wallet</a>
-            <a routerLink="/preferences"> Preferences </a>
-            <hr class="wide">
-            <a (click)="logout()"> Logout</a>
+        <app-drop-down>
+            <!-- Dropdown Button -->
+            <button dropdown-button class="btn2">
+                <lucide-icon [img]="UserIcon" size="18"></lucide-icon>
+                {{ session.actor }}
+            </button>
+
+            <!-- Dropdown Body -->
+            <div dropdown-body class="body">
+                <a routerLink="/wallet">Wallet</a>
+                <a routerLink="/preferences">Preferences</a>
+                <hr class="wide">
+                <a (click)="logout()">Logout</a>
+            </div>
         </app-drop-down>
     </div>
 </div>

--- a/src/app/components/login/login.component.scss
+++ b/src/app/components/login/login.component.scss
@@ -6,3 +6,9 @@ hr.wide {
     background-color: var(--c-background-4);
     height: 1px;
 }
+
+.body{
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { DropDownComponent } from '@app/components/base-components/drop-down/drop-down.component';
 import { RouterModule } from '@angular/router';
 import { SessionService } from '@app/services/session-kit.service';
+import { LucideAngularModule, User, LogIn } from 'lucide-angular';
 
 @Component({
     selector: 'app-login',
@@ -11,11 +12,14 @@ import { SessionService } from '@app/services/session-kit.service';
         CommonModule,
         DropDownComponent,
         RouterModule,
+        LucideAngularModule
     ],
     templateUrl: './login.component.html',
     styleUrls: ['./login.component.scss'],
 })
 export class LoginComponent {
+    readonly UserIcon = User
+
     constructor(public sessionService: SessionService) {}
 
     async login() {

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -29,5 +29,4 @@ export class LoginComponent {
     async logout() {
         await this.sessionService.logout();
     }
-
 }

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.html
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.html
@@ -2,9 +2,6 @@
 
     <p class="header">Mobile side-menu head</p>
 
-    <br>
-    <br>
-    <p class="option small">DEX</p>
     <hr class="wide">
 
     <a class="option" routerLink="/trade" routerLinkActive="active-link">
@@ -20,9 +17,6 @@
         <p>Pool</p>
     </a>
 
-    <br>
-    <br>
-    <p class="option small">User</p>
     <hr class="wide">
 
     <a class="option" routerLink="/wallet" routerLinkActive="active-link">

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.html
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.html
@@ -3,7 +3,8 @@
     <p class="header">Mobile side-menu head</p>
 
     <br>
-    <p class="small">DEX</p>
+    <br>
+    <p class="option small">DEX</p>
     <hr class="wide">
 
     <a class="option" routerLink="/trade" routerLinkActive="active-link">
@@ -20,7 +21,8 @@
     </a>
 
     <br>
-    <p class="small">User</p>
+    <br>
+    <p class="option small">User</p>
     <hr class="wide">
 
     <a class="option" routerLink="/wallet" routerLinkActive="active-link">
@@ -29,7 +31,7 @@
     </a>
 
     <a class="option" routerLink="/preferences" routerLinkActive="active-link">
-        <lucide-icon [img]="ListChecksIcon"></lucide-icon>
+        <lucide-icon [img]="SettingsIcon"></lucide-icon>
         <p>Preferences</p>
     </a>
 

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.html
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.html
@@ -2,6 +2,8 @@
 
     <p class="header">Mobile side-menu head</p>
 
+    <br>
+    <p class="small">DEX</p>
     <hr class="wide">
 
     <a class="option" routerLink="/trade" routerLinkActive="active-link">
@@ -17,16 +19,25 @@
         <p>Pool</p>
     </a>
 
+    <br>
+    <p class="small">User</p>
     <hr class="wide">
 
     <a class="option" routerLink="/wallet" routerLinkActive="active-link">
         <lucide-icon [img]="WalletIcon"></lucide-icon>
         <p>Wallet</p>
     </a>
+
     <a class="option" routerLink="/preferences" routerLinkActive="active-link">
         <lucide-icon [img]="ListChecksIcon"></lucide-icon>
         <p>Preferences</p>
     </a>
+
+    <a class="option" routerLink="/accounts" routerLinkActive="active-link">
+        <lucide-icon [img]="UsersIcon"></lucide-icon>
+        <p>Accounts</p>
+    </a>
+
     <a class="option" routerLink="/" routerLinkActive="active-link" (click)="logout()">
         <lucide-icon [img]="LogoutIcon"></lucide-icon>
         <p>Logout</p>

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.scss
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.scss
@@ -29,3 +29,4 @@ hr.wide {
     background-color: var(--c-background-4);
     height: 1px;
 }
+

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
@@ -8,6 +8,7 @@ import {
     Wallet,
     LogOut,
     ListTree,
+    Users
 } from 'lucide-angular';
 import { RouterModule } from '@angular/router';
 import { SessionService } from '@app/services/session-kit.service';
@@ -29,6 +30,7 @@ export class SideMenuMobileComponent {
     readonly WalletIcon = Wallet;
     readonly LogoutIcon = LogOut;
     readonly ListTreeIcon = ListTree;
+    readonly UsersIcon = Users
 
     constructor(
         public sessionService: SessionService

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
@@ -3,7 +3,7 @@ import { SideContainerComponent } from '@app/components/base-components/side-con
 import {
     LucideAngularModule,
     ChartCandlestick,
-    ListChecks,
+    Settings,
     Coins,
     Wallet,
     LogOut,
@@ -25,7 +25,7 @@ import { SessionService } from '@app/services/session-kit.service';
 })
 export class SideMenuMobileComponent {
     readonly ChartCandlestickIcon = ChartCandlestick;
-    readonly ListChecksIcon = ListChecks;
+    readonly SettingsIcon = Settings;
     readonly CoinsIcon = Coins;
     readonly WalletIcon = Wallet;
     readonly LogoutIcon = LogOut;

--- a/src/app/pages/accounts/accounts.component.html
+++ b/src/app/pages/accounts/accounts.component.html
@@ -1,5 +1,16 @@
 <div class="accountsContainer">
     <h2>Accounts</h2>
-    <p class="small">Please log in to continue</p>
-    <app-login></app-login>
+
+    <ng-container *ngIf="sessionService.session$ | async as session; else loginTemplate">
+        <p>Connected as: {{ session.actor }}</p>
+
+        <div class="contained">
+            <p class="small"> Accounts list goes here . . .</p>
+        </div>
+    </ng-container>
+
+    <ng-template #loginTemplate>
+        <p class="small">Please log in to continue</p>
+        <app-login></app-login>
+    </ng-template>
 </div>

--- a/src/app/pages/accounts/accounts.component.html
+++ b/src/app/pages/accounts/accounts.component.html
@@ -3,10 +3,10 @@
 
     <ng-container *ngIf="sessionService.session$ | async as session; else loginTemplate">
         <p>Connected as: {{ session.actor }}</p>
+        <p class="small contained"> Accounts list goes here <br>-<br>-<br>-</p>
+        <a class="add">+ Add new account</a>
 
-        <div class="contained">
-            <p class="small"> Accounts list goes here . . .</p>
-        </div>
+
     </ng-container>
 
     <ng-template #loginTemplate>

--- a/src/app/pages/accounts/accounts.component.html
+++ b/src/app/pages/accounts/accounts.component.html
@@ -5,8 +5,6 @@
         <p>Connected as: {{ session.actor }}</p>
         <p class="small contained"> Accounts list goes here <br>-<br>-<br>-</p>
         <a class="add">+ Add new account</a>
-
-
     </ng-container>
 
     <ng-template #loginTemplate>

--- a/src/app/pages/accounts/accounts.component.html
+++ b/src/app/pages/accounts/accounts.component.html
@@ -1,0 +1,5 @@
+<div class="accountsContainer">
+    <h2>Accounts</h2>
+    <p class="small">Please log in to continue</p>
+    <app-login></app-login>
+</div>

--- a/src/app/pages/accounts/accounts.component.scss
+++ b/src/app/pages/accounts/accounts.component.scss
@@ -3,3 +3,11 @@
     flex-direction: column;
     gap: 10px;
 }
+
+.add{
+    color: var(--c-accent-0);
+
+    &:hover{
+        color: var(--c-foreground-2);
+    }
+}

--- a/src/app/pages/accounts/accounts.component.scss
+++ b/src/app/pages/accounts/accounts.component.scss
@@ -1,0 +1,5 @@
+.accountsContainer{
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}

--- a/src/app/pages/accounts/accounts.component.ts
+++ b/src/app/pages/accounts/accounts.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { LoginComponent } from '@app/components/login/login.component';
+
+@Component({
+  selector: 'app-accounts',
+  imports: [LoginComponent],
+  templateUrl: './accounts.component.html',
+  styleUrl: './accounts.component.scss'
+})
+export class AccountsComponent {
+
+}

--- a/src/app/pages/accounts/accounts.component.ts
+++ b/src/app/pages/accounts/accounts.component.ts
@@ -1,12 +1,15 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { LoginComponent } from '@app/components/login/login.component';
+import { SessionService } from '@app/services/session-kit.service';
 
 @Component({
-  selector: 'app-accounts',
-  imports: [LoginComponent],
-  templateUrl: './accounts.component.html',
-  styleUrl: './accounts.component.scss'
+    selector: 'app-accounts',
+    standalone: true,
+    imports: [CommonModule, LoginComponent],
+    templateUrl: './accounts.component.html',
+    styleUrls: ['./accounts.component.scss']
 })
 export class AccountsComponent {
-
+    constructor(public sessionService: SessionService) {}
 }

--- a/src/app/pages/wallet/wallet.component.html
+++ b/src/app/pages/wallet/wallet.component.html
@@ -9,7 +9,6 @@
         <p>[ Loading... ]</p>
     </div>
 
-
     <ng-template #balanceList>
         <app-expandable-group>
             <app-expandable *ngFor="let balance of balances">

--- a/src/app/services/redirect.services.ts
+++ b/src/app/services/redirect.services.ts
@@ -1,0 +1,55 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { Router } from '@angular/router';
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { SessionService } from '@app/services/session-kit.service';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { BREAKPOINT } from 'src/types';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class RedirectService implements OnDestroy {
+    private destroy$ = new Subject<void>();
+
+    constructor(
+        private router: Router,
+        private sessionService: SessionService,
+        private breakpointObserver: BreakpointObserver
+    ) {
+        this.setupRedirectLogic();
+    }
+
+    private setupRedirectLogic() {
+        let isMobile = false;
+
+        // Detect mobile/desktop
+        this.breakpointObserver.observe(BREAKPOINT)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(result => {
+                isMobile = result.matches;
+            });
+
+        // Listen for authentication changes
+        this.sessionService.session$
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(session => {
+                if (session) {
+                    if (isMobile) {
+                        this.router.navigate(['/wallet']);
+                    }
+                } else {
+                    if (isMobile) {
+                        this.router.navigate(['/accounts']);
+                    } else {
+                        this.router.navigate(['/']);
+                    }
+                }
+            });
+    }
+
+    ngOnDestroy() {
+        this.destroy$.next();
+        this.destroy$.complete();
+    }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -104,6 +104,9 @@ a {
 }
 
 .btn {
+    display: flex;
+    align-items: center;
+    gap: 10px;
     font-size: 10pt;
     padding: 10px 20px;
     color: var(--c-background-0);
@@ -121,6 +124,9 @@ a {
     }
 }
 .btn2 {
+    display: flex;
+    align-items: center;
+    gap: 10px;
     font-size: 10pt;
     padding: 10px 20px;
     color: var(--c-accent-0);


### PR DESCRIPTION
# Fix #31 
This is a sub-issue from #26 


## Description

Changes were made:
- New `pages/accounts/*`
- New `services/redirect.service.ts`
- Enhanced `base-components/drop-down/*`
- Enhanced `components/login/*`

<br>

## Accounts page
Accessible though the user drop-down and the mobile side-menu.
It has two placeholder states:

_Unauthenticated Users_
![2025-03-20-182050_238x221_scrot](https://github.com/user-attachments/assets/944a3dbf-4291-45b7-a974-0fe4411535cf)

_Authenticated Users_
![2025-03-20-213144_341x358_scrot](https://github.com/user-attachments/assets/cb7d8ff2-0f29-400d-b3ab-a14ac445f8b0)

<br>

## Redirect Service
Injected in app.component.

In charge of:
- Detect authentication changes.
- Detect viewport size (mobile vs. desktop).
- Redirect based on login/logout status.

When the site is running on the mobile platform:
- Authenticated users redirected to the wallet section.
- Unauthenticated users redirected to the Accounts section.

If a user logs out:
- On the mobile platform, they redirected to the Accounts section.
- On the desktop platform, they redirected to the Home section.

<br>

## Drop-down component
Now this reusable component uses `<ng-content>` to define its button text. 

<br>

## Login component
Now this component has a "btn2" style on its user state button, plus a user icon.
![2025-03-20-212953_227x75_scrot](https://github.com/user-attachments/assets/c3de2037-af59-4bc9-8548-43ec50c3a2fa)
![2025-03-20-213023_286x72_scrot](https://github.com/user-attachments/assets/6c1a89f3-137a-4764-b25c-414c642c3f35)




