### PR TITLE
Proposal for enhancing navigation experience

### DIFF
--- a/public/assets/locals/en.json
+++ b/public/assets/locals/en.json
@@ -1,15 +1,101 @@
 {
     "PAGES": {
         "HOME": {
+            "NAME": "Home",
             "TITLE": "DEX",
-            "DESCRIPTION": "A peer-to-peer marketplace where transactions occur directly between crypto traders."
+            "DESCRIPTION": "A peer-to-peer marketplace where transactions occur directly between cryptocurrency traders."
+        },
+        "TRADE": {
+            "NAME": "Trading",
+            "TITLE": "Trading Page",
+            "DESCRIPTION": "Description!"
         },
         "EXPLORE": {
-            "TITLE": "Explore Page",
+            "NAME": "Explore",
+            "TITLE": "Exploration Page",
             "DESCRIPTION": "Discover new content here!"
+        },
+        "POOL": {
+            "NAME": "Pool",
+            "TITLE": "Liquidity Pool Page",
+            "DESCRIPTION": "Description!"
+        },
+        "WALLET": {
+            "NAME": "Wallet",
+            "ERROR": "No active session. Log in to continue.",
+            "TITLE": "Wallet",
+            "DESCRIPTION": "Your token balance",
+            "LOADING": "Loading..."
+        },
+        "PREFERENCES": {
+            "NAME": "Preferences",
+            "TITLE": "User Preferences",
+            "DESCRIPTION": "Preferences will be remembered for each user.",
+            "MODE": {
+                "TITLE": "Mode",
+                "DARK": "Dark",
+                "LIGHT": "Light"
+            },
+            "HUE": {
+                "TITLE": "Hue",
+                "A": "Ocean",
+                "B": "Igneous",
+                "C": "Emerald"
+            }
+        },
+        "ACCOUNTS": {
+            "NAME": "Accounts",
+            "TITLE": "Acounts Page",
+            "DESCRIPTION": "Your accounts are stored here.",
+            "ERROR": "Log in to continue.",
+            "CONNECTED": "Connected as:",
+            "ADD": "Add new account"
         }
     },
     "COMPONENTS": {
-        
+        "TRANSFER-FORM": {
+            "TITLE": "Transfer",
+            "AVAILABLE": "Available:",
+            "TO": {
+                "TITLE": "Transfer to:",
+                "INPUT": "Enter recipient username",
+                "VALIDATION": {
+                    "CHECKING": "⏳ Verifying User",
+                    "INVALID-PATTERN": "❌ Invalid EOSIO pattern, 1-12 characters (a-z, 1-5)",
+                    "INVALID-SELF": "❌ Cannot send to yourself",
+                    "INVALID-EXIST": "❌ User does not exist",
+                    "VALID": "✅ Valid User"
+                }
+            },
+            "AMOUNT": {
+                "TITLE": "Amount:",
+                "INPUT": "Enter a whole number",
+                "USE-MAX": "Use All",
+                "VALIDATION": {
+                    "INVALID-AMOUNT": "❌ Invalid amount",
+                    "INVALID-MAX": "❌ Amount exceeds your balance",
+                    "VALID": "✅ Valid Amount"
+                }
+            },
+            "SUCCESS": "✅ Transaction Successful",
+            "FAILURE": "❌ Transaction Failed"
+        }
+    },
+    "TYPES": {
+        "BUTTON": {
+            "REFRESH": "Refresh",
+            "RETRY": "Retry",
+            "CLOSE": "Close",
+            "TRANSFER": "Transfer",
+            "PROCESSING": "Processing...",
+            "LOGIN": "Log In",
+            "LOGOUT": "Log out"
+        },
+        "TRANSFER-SUMMARY": {
+            "FROM": "From:",
+            "TO": "To:",
+            "AMOUNT": "Amount:",
+            "TRANSACTION": "Transaction:"
+        }
     }
 }

--- a/public/assets/locals/en.json
+++ b/public/assets/locals/en.json
@@ -30,7 +30,12 @@
         "PREFERENCES": {
             "NAME": "Preferences",
             "TITLE": "User Preferences",
-            "DESCRIPTION": "Preferences will be remembered for each user.",
+            "DESCRIPTION": "Costomize your environment",
+            "LANGUAGE": {
+                "TITLE": "Language",
+                "EN": "English",
+                "ES": "Spanish"
+            },
             "MODE": {
                 "TITLE": "Mode",
                 "DARK": "Dark",

--- a/public/assets/locals/en.json
+++ b/public/assets/locals/en.json
@@ -93,8 +93,8 @@
             "CLOSE": "Close",
             "TRANSFER": "Transfer",
             "PROCESSING": "Processing...",
-            "LOGIN": "Log In",
-            "LOGOUT": "Log out"
+            "LOGIN": "LogIn",
+            "LOGOUT": "LogOut"
         },
         "TRANSFER-SUMMARY": {
             "FROM": "From:",

--- a/public/assets/locals/en.json
+++ b/public/assets/locals/en.json
@@ -6,7 +6,7 @@
             "DESCRIPTION": "A peer-to-peer marketplace where transactions occur directly between cryptocurrency traders."
         },
         "TRADE": {
-            "NAME": "Trading",
+            "NAME": "Trade",
             "TITLE": "Trading Page",
             "DESCRIPTION": "Description!"
         },

--- a/public/assets/locals/es.json
+++ b/public/assets/locals/es.json
@@ -1,15 +1,101 @@
 {
     "PAGES": {
         "HOME": {
+            "NAME": "Inicio",
             "TITLE": "DEX",
             "DESCRIPTION": "Un mercado peer-to-peer donde las transacciones se realizan directamente entre operadores de criptomonedas."
         },
+        "TRADE": {
+            "NAME": "Tradeo",
+            "TITLE": "Página de Tradeo",
+            "DESCRIPTION": "¡Descripción!"
+        },
         "EXPLORE": {
+            "NAME": "Explorar",
             "TITLE": "Página de Exploración",
             "DESCRIPTION": "¡Descubre nuevo contenido aquí!"
+        },
+        "POOL": {
+            "NAME": "Piscina",
+            "TITLE": "Página de Piscina de Liquidez",
+            "DESCRIPTION": "¡Descripción!"
+        },
+        "WALLET": {
+            "NAME": "Billetera",
+            "ERROR": "Ninguna sesión activa. Inicia sesión para continuar",
+            "TITLE": "Billetera",
+            "DESCRIPTION": "Balance de tus tokens",
+            "LOADING": "Cargando..."
+        },
+        "PREFERENCES": {
+            "NAME": "Preferencias",
+            "TITLE": "Preferencias de Usuario",
+            "DESCRIPTION": "Las preferencias serán recordadas para cada usuario",
+            "MODE": {
+                "TITLE": "Modo",
+                "DARK": "Oscuro",
+                "LIGHT": "Claro"
+            },
+            "HUE": {
+                "TITLE": "Color",
+                "A": "Océano",
+                "B": "Ígneo",
+                "C": "Esmeralda"
+            }
+        },
+        "ACCOUNTS": {
+            "NAME": "Sesiones",
+            "TITLE": "Página de Sesiones",
+            "DESCRIPTION": "Aquí se guardan tus distintas sessiones",
+            "ERROR": "Inicia sesión para continuar",
+            "CONNECTED": "Conectado como:",
+            "ADD": "Agregar cuenta"
         }
     },
     "COMPONENTS": {
-        
+        "TRANSFER-FORM": {
+            "TITLE": "Transferir",
+            "AVAILABLE": "Disponible:",
+            "TO": {
+                "TITLE": "Transferir a:",
+                "INPUT": "Inserte usuario destinatario",
+                "VALIDATION": {
+                    "CHECKING": "⏳ Verificando Usuario",
+                    "INVALID-PATTERN": "❌ Patrón EOSIO Incorrecto, 1-12 caracteres (a-z, 1-5)",
+                    "INVALID-SELF": "❌ No puede enviar a sí mismo",
+                    "INVALID-EXIST": "❌ El usuario no existe",
+                    "VALID": "✅ Usuario Válido"
+                }
+            },
+            "AMOUNT": {
+                "TITLE": "Cantidad:",
+                "INPUT": "Inserte número entero",
+                "USE-MAX": "Usar Todo",
+                "VALIDATION": {
+                    "INVALID-AMOUNT": "❌ Cantidad errónea",
+                    "INVALID-MAX": "❌ Cantidad supera su balance",
+                    "VALID": "✅ Cantidad Válida"
+                }
+            },
+            "SUCCESS": "✅ Transacción Exitosa",
+            "FAILURE": "❌ Transacción Fallida"
+        }
+    },
+    "TYPES": {
+        "BUTTON": {
+            "REFRESH": "Actualizar",
+            "RETRY": "Reintentar",
+            "CLOSE": "Cerrar",
+            "TRANSFER": "Transferir",
+            "PROCESSING": "Procesando...",
+            "LOGIN": "Iniciar Sesión",
+            "LOGOUT": "Cerrar Sesión"
+        },
+        "TRANSFER-SUMMARY": {
+            "FROM": "Origen:",
+            "TO": "Destino:",
+            "AMOUNT": "Cantidad:",
+            "TRANSACTION": "Transacción:"
+        }
     }
 }

--- a/public/assets/locals/es.json
+++ b/public/assets/locals/es.json
@@ -30,7 +30,12 @@
         "PREFERENCES": {
             "NAME": "Preferencias",
             "TITLE": "Preferencias de Usuario",
-            "DESCRIPTION": "Las preferencias serán recordadas para cada usuario",
+            "DESCRIPTION": "Configure su entorno",
+            "LANGUAGE": {
+                "TITLE": "Idioma",
+                "EN": "Ingles",
+                "ES": "Español"
+            },
             "MODE": {
                 "TITLE": "Modo",
                 "DARK": "Oscuro",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -29,30 +29,10 @@ export class AppComponent {
 
 
     constructor(
-        private redirectService: RedirectService,
+        private redirectService: RedirectService, //Automatically sets redirection rules
         private translate: TranslateService,
     ) {
         // Set default language
-        this.translate.setDefaultLang('en');
         this.translate.use('en');
-
-        // FIXME: Remove this section (is for testing only) -----------------------------
-        let count = 2;
-        let isEnglish = true;
-
-        const interval = setInterval(() => {
-            console.log(`Changing language in ${count} seconds`);
-            count--;
-
-            if (count === 0) {
-                isEnglish = !isEnglish;
-                const newLang = isEnglish ? 'en' : 'es';
-                console.log(`Changing language to ${newLang.toUpperCase()}`);
-                this.translate.use(newLang);
-
-                count = 2; // Reset countdown
-            }
-        }, 1000);
-        // ------------------------------------------------------------------------------
     }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { NavBarComponent } from '@app/components/nav-bar/nav-bar.component';
-import { SideMenuMobileComponent } from '@app/components/side-menu-mobile/side-menu-mobile.component';
+import { UserSideMenuComponent } from '@app/components/user-side-menu/user-side-menu.component';
 import { RedirectService } from '@app/services/redirect.services';
 import { SharedModule } from '@app/shared/shared.module';
 import { TranslateService } from '@ngx-translate/core';
@@ -12,7 +12,7 @@ import { TranslateService } from '@ngx-translate/core';
     imports: [
         RouterOutlet,
         NavBarComponent,
-        SideMenuMobileComponent,
+        UserSideMenuComponent,
         SharedModule
     ],
     template: `
@@ -20,7 +20,7 @@ import { TranslateService } from '@ngx-translate/core';
         <div class='view'>
             <router-outlet></router-outlet>
         </div>
-        <app-side-menu-mobile></app-side-menu-mobile>
+        <app-user-side-menu></app-user-side-menu>
     `,
     styleUrls: ['./app.component.scss']
 })

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -27,25 +27,30 @@ import { TranslateService } from '@ngx-translate/core';
 export class AppComponent {
     title = 'my-angular-app';
 
+
     constructor(
         private redirectService: RedirectService,
         private translate: TranslateService,
     ) {
         // Set default language
         this.translate.setDefaultLang('en');
-        // Use default language
         this.translate.use('en');
 
         // FIXME: Remove this section (is for testing only) -----------------------------
-        // changint the language in 5 seconds to es with a console count down by seconds
-        let count = 5;
+        let count = 2;
+        let isEnglish = true;
+
         const interval = setInterval(() => {
             console.log(`Changing language in ${count} seconds`);
             count--;
+
             if (count === 0) {
-                clearInterval(interval);
-                console.log('Changing language to Español');
-                this.translate.use('es');
+                isEnglish = !isEnglish;
+                const newLang = isEnglish ? 'en' : 'es';
+                console.log(`Changing language to ${newLang.toUpperCase()}`);
+                this.translate.use(newLang);
+
+                count = 2; // Reset countdown
             }
         }, 1000);
         // ------------------------------------------------------------------------------

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -3,7 +3,7 @@
         class="c-login__btn"
         (click)="login()"
         *ngIf="!(sessionService.session$ | async)"
-    >Login</button>
+    >{{'TYPES.BUTTON.LOGIN' | translate}}</button>
 
     <div class="c-login__menu" *ngIf="(sessionService.session$ | async) as session">
         <app-drop-down>
@@ -15,11 +15,11 @@
 
             <!-- Dropdown Body -->
             <div dropdown-body class="c-login__menu-body">
-                <a class="c-login__menu-option" routerLink="/wallet">Wallet</a>
-                <a class="c-login__menu-option" routerLink="/accounts">Accounts</a>
-                <a class="c-login__menu-option" routerLink="/preferences">Preferences</a>
+                <a class="c-login__menu-option" routerLink="/wallet">{{'PAGES.WALLET.NAME' | translate}}</a>
+                <a class="c-login__menu-option" routerLink="/accounts">{{'PAGES.ACCOUNTS.NAME' | translate}}</a>
+                <a class="c-login__menu-option" routerLink="/preferences">{{'PAGES.PREFERENCES.NAME' | translate}}</a>
                 <hr class="c-login__menu-separator">
-                <a class="c-login__menu-option" (click)="logout()">Logout</a>
+                <a class="c-login__menu-option" (click)="logout()">{{'TYPES.BUTTON.LOGOUT' | translate}}</a>
             </div>
         </app-drop-down>
     </div>

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -6,21 +6,9 @@
     >{{'TYPES.BUTTON.LOGIN' | translate}}</button>
 
     <div class="c-login__menu" *ngIf="(sessionService.session$ | async) as session">
-        <app-drop-down>
-            <!-- Dropdown Button -->
-            <button dropdown-button class="c-login__btn--active">
+            <button class="c-login__btn--active" (click)="toggleMobileSideMenu()">
                 <lucide-icon [img]="UserIcon" size="18"></lucide-icon>
                 {{ session.actor }}
             </button>
-
-            <!-- Dropdown Body -->
-            <div dropdown-body class="c-login__menu-body">
-                <a class="c-login__menu-option" routerLink="/wallet">{{'PAGES.WALLET.NAME' | translate}}</a>
-                <a class="c-login__menu-option" routerLink="/accounts">{{'PAGES.ACCOUNTS.NAME' | translate}}</a>
-                <a class="c-login__menu-option" routerLink="/preferences">{{'PAGES.PREFERENCES.NAME' | translate}}</a>
-                <hr class="c-login__menu-separator">
-                <a class="c-login__menu-option" (click)="logout()">{{'TYPES.BUTTON.LOGOUT' | translate}}</a>
-            </div>
-        </app-drop-down>
     </div>
 </div>

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -6,7 +6,7 @@
     >{{'TYPES.BUTTON.LOGIN' | translate}}</button>
 
     <div class="c-login__menu" *ngIf="(sessionService.session$ | async) as session">
-            <button class="c-login__btn--active" (click)="toggleMobileSideMenu()">
+            <button class="c-login__btn" (click)="toggleMobileSideMenu()">
                 <lucide-icon [img]="UserIcon" size="18"></lucide-icon>
                 {{ session.actor }}
             </button>

--- a/src/app/components/login/login.component.scss
+++ b/src/app/components/login/login.component.scss
@@ -3,10 +3,6 @@
 .c-login {
     &__btn {
         @include button-0;
-
-        &--active {
-            @include button-1
-        }
     }
     &__menu {
         &-body {

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -42,6 +42,6 @@ export class LoginComponent {
     }
 
     toggleMobileSideMenu() {
-        this.sideContainerService.toggle('mobile-side-menu');
+        this.sideContainerService.toggle('user-side-menu');
     }
 }

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -1,18 +1,17 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { DropDownComponent } from '@app/components/base-components/drop-down/drop-down.component';
 import { RouterModule } from '@angular/router';
 import { SessionService } from '@app/services/session-kit.service';
 import { LucideAngularModule, User } from 'lucide-angular';
 import { ExpandableManagerService } from '../base-components/expandable/expandable-manager.service';
 import { SharedModule } from '@app/shared/shared.module';
+import { SideContainerService } from '../base-components/side-container/side-container.service';
 
 @Component({
     selector: 'app-login',
     standalone: true,
     imports: [
         CommonModule,
-        DropDownComponent,
         RouterModule,
         LucideAngularModule,
         SharedModule
@@ -26,6 +25,7 @@ export class LoginComponent {
     constructor(
         public sessionService: SessionService,
         public expandibles: ExpandableManagerService,
+        private sideContainerService: SideContainerService,
     ) {}
 
     async login() {
@@ -39,5 +39,9 @@ export class LoginComponent {
     async logout() {
         await this.sessionService.logout();
         this.expandibles.closeAll();
+    }
+
+    toggleMobileSideMenu() {
+        this.sideContainerService.toggle('mobile-side-menu');
     }
 }

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -5,6 +5,7 @@ import { RouterModule } from '@angular/router';
 import { SessionService } from '@app/services/session-kit.service';
 import { LucideAngularModule, User } from 'lucide-angular';
 import { ExpandableManagerService } from '../base-components/expandable/expandable-manager.service';
+import { SharedModule } from '@app/shared/shared.module';
 
 @Component({
     selector: 'app-login',
@@ -13,7 +14,8 @@ import { ExpandableManagerService } from '../base-components/expandable/expandab
         CommonModule,
         DropDownComponent,
         RouterModule,
-        LucideAngularModule
+        LucideAngularModule,
+        SharedModule
     ],
     templateUrl: './login.component.html',
     styleUrls: ['./login.component.scss'],

--- a/src/app/components/nav-bar/nav-bar.component.html
+++ b/src/app/components/nav-bar/nav-bar.component.html
@@ -60,12 +60,19 @@
 
             <app-login></app-login>
 
-            <lucide-icon dropdown-button
-                [img]="SettingsIcon"
-                class="c-navbar__icon"
-                routerLink="/preferences"
-                routerLinkActive="active-link"
-            ></lucide-icon>
+            <app-drop-down>
+                <!-- Dropdown Button -->
+                <lucide-icon dropdown-button
+                    [img]="GlobeIcon"
+                    class="c-navbar__icon"
+                ></lucide-icon>
+
+                <!-- Dropdown Body -->
+                <div dropdown-body class="c-navbar__dropdown">
+                    <a class="c-navbar__dropdown-option" (click)="setLang('en')">{{ 'PAGES.PREFERENCES.LANGUAGE.EN' | translate }}</a>
+                    <a class="c-navbar__dropdown-option" (click)="setLang('es')">{{ 'PAGES.PREFERENCES.LANGUAGE.ES' | translate }}</a>
+                </div>
+            </app-drop-down>
         </div>
     </nav>
 </ng-template>

--- a/src/app/components/nav-bar/nav-bar.component.html
+++ b/src/app/components/nav-bar/nav-bar.component.html
@@ -20,9 +20,9 @@
                 </svg>
             </a>
 
-            <a class="c-navbar__button" routerLink="/trade" routerLinkActive="active-link">Trade</a>
-            <a class="c-navbar__button" routerLink="/explore" routerLinkActive="active-link">Explore</a>
-            <a class="c-navbar__button" routerLink="/pool" routerLinkActive="active-link">Pool</a>
+            <a class="c-navbar__button" routerLink="/trade" routerLinkActive="active-link">{{ 'PAGES.TRADE.NAME' | translate }}</a>
+            <a class="c-navbar__button" routerLink="/explore" routerLinkActive="active-link">{{ 'PAGES.EXPLORE.NAME' | translate }}</a>
+            <a class="c-navbar__button" routerLink="/pool" routerLinkActive="active-link">{{ 'PAGES.POOL.NAME' | translate }}</a>
         </div>
 
         <div class="c-navbar__row">
@@ -36,8 +36,8 @@
 
                 <!-- Dropdown Body -->
                 <div dropdown-body class="c-navbar__dropdown">
-                    <a class="c-navbar__dropdown-option" (click)="setLang('en')">english</a>
-                    <a class="c-navbar__dropdown-option" (click)="setLang('es')">spanish</a>
+                    <a class="c-navbar__dropdown-option" (click)="setLang('en')">{{ 'PAGES.PREFERENCES.LANGUAGE.EN' | translate }}</a>
+                    <a class="c-navbar__dropdown-option" (click)="setLang('es')">{{ 'PAGES.PREFERENCES.LANGUAGE.ES' | translate }}</a>
                 </div>
             </app-drop-down>
 

--- a/src/app/components/nav-bar/nav-bar.component.html
+++ b/src/app/components/nav-bar/nav-bar.component.html
@@ -1,10 +1,10 @@
 <!-- Normal Navbar -->
 <!-- [ngIf]="!isMobileView; else mobileNav" -->
 <ng-container *ngIf="!isMobileView; else mobileNav">
-    <nav class="c-nabvar">
-        <div class="c-nabvar__row">
+    <nav class="c-navbar">
+        <div class="c-navbar__row">
             <a
-                class="c-nabvar__logo"
+                class="c-navbar__logo"
                 routerLink="/"
                 routerLinkActive="active-link"
                 [routerLinkActiveOptions]="{ exact: true }"
@@ -20,16 +20,30 @@
                 </svg>
             </a>
 
-            <a class="c-nabvar__button" routerLink="/trade" routerLinkActive="active-link">Trade</a>
-            <a class="c-nabvar__button" routerLink="/explore" routerLinkActive="active-link">Explore</a>
-            <a class="c-nabvar__button" routerLink="/pool" routerLinkActive="active-link">Pool</a>
-
+            <a class="c-navbar__button" routerLink="/trade" routerLinkActive="active-link">Trade</a>
+            <a class="c-navbar__button" routerLink="/explore" routerLinkActive="active-link">Explore</a>
+            <a class="c-navbar__button" routerLink="/pool" routerLinkActive="active-link">Pool</a>
         </div>
 
-        <div class="c-nabvar__row">
+        <div class="c-navbar__row">
+
+            <app-drop-down>
+                <!-- Dropdown Button -->
+                <lucide-icon dropdown-button
+                    [img]="GlobeIcon"
+                    class="c-navbar__icon"
+                ></lucide-icon>
+
+                <!-- Dropdown Body -->
+                <div dropdown-body class="c-navbar__dropdown">
+                    <a class="c-navbar__dropdown-option" (click)="setLang('en')">english</a>
+                    <a class="c-navbar__dropdown-option" (click)="setLang('es')">spanish</a>
+                </div>
+            </app-drop-down>
+
             <lucide-icon
                 [img]="isDarkTheme ? SunIcon : MoonIcon"
-                class="c-nabvar__icon"
+                class="c-navbar__icon"
                 (click)="toggleTheme()"
             ></lucide-icon>
             <app-login></app-login>
@@ -40,13 +54,13 @@
 <!-- Mobile Navbar | whidth < 599px -->
 
 <ng-template #mobileNav>
-    <nav class="c-nabvar">
-        <div class="c-nabvar__row c-nabvar__row--mobile">
-            <lucide-icon [img]="QrIcon" class="c-nabvar__icon c-nabvar__icon--btn"></lucide-icon>
+    <nav class="c-navbar">
+        <div class="c-navbar__row c-navbar__row--mobile">
+            <lucide-icon [img]="QrIcon" class="c-navbar__icon c-navbar__icon--btn"></lucide-icon>
 
             <app-login></app-login>
 
-            <lucide-icon [img]="MenuIcon" class="c-nabvar__icon c-nabvar__icon--btn" (click)="toggleMobileSideMenu()"></lucide-icon>
+            <lucide-icon [img]="MenuIcon" class="c-navbar__icon c-navbar__icon--btn" (click)="toggleMobileSideMenu()"></lucide-icon>
         </div>
     </nav>
 </ng-template>

--- a/src/app/components/nav-bar/nav-bar.component.html
+++ b/src/app/components/nav-bar/nav-bar.component.html
@@ -60,7 +60,12 @@
 
             <app-login></app-login>
 
-            <lucide-icon [img]="MenuIcon" class="c-navbar__icon c-navbar__icon--btn" (click)="toggleMobileSideMenu()"></lucide-icon>
+            <lucide-icon dropdown-button
+                [img]="SettingsIcon"
+                class="c-navbar__icon"
+                routerLink="/preferences"
+                routerLinkActive="active-link"
+            ></lucide-icon>
         </div>
     </nav>
 </ng-template>

--- a/src/app/components/nav-bar/nav-bar.component.scss
+++ b/src/app/components/nav-bar/nav-bar.component.scss
@@ -1,6 +1,6 @@
 @use 'mixin' as *;
 
-.c-nabvar {
+.c-navbar {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -28,11 +28,17 @@
 
     &__icon {
         @include hyperlink;
-        margin-top: 6px;
+        @include icon
     }
 
+    &__dropdown{
+        display: flex;
+        flex-direction: column;
+        gap: 15px;
+        padding: 10px;
 
+        &-option{
+            @include hyperlink
+        }
+    }
 }
-
-
-

--- a/src/app/components/nav-bar/nav-bar.component.ts
+++ b/src/app/components/nav-bar/nav-bar.component.ts
@@ -12,6 +12,7 @@ import { BREAKPOINT } from 'src/types';
 import { SideContainerService } from '@app/components/base-components/side-container/side-container.service';
 import { DropDownComponent } from '../base-components/drop-down/drop-down.component';
 import { TranslateService } from '@ngx-translate/core';
+import { SharedModule } from '@app/shared/shared.module';
 
 @Component({
     selector: 'app-nav-bar',
@@ -21,7 +22,8 @@ import { TranslateService } from '@ngx-translate/core';
         RouterModule,
         LoginComponent,
         LucideAngularModule,
-        DropDownComponent
+        DropDownComponent,
+        SharedModule
     ],
     templateUrl: './nav-bar.component.html',
     styleUrls: ['./nav-bar.component.scss']

--- a/src/app/components/nav-bar/nav-bar.component.ts
+++ b/src/app/components/nav-bar/nav-bar.component.ts
@@ -7,9 +7,11 @@ import { RouterModule } from '@angular/router';
 import { LoginComponent } from '../login/login.component';
 import { Subject, takeUntil } from 'rxjs';
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { LucideAngularModule, Menu, ScanQrCode, Sun, Moon} from 'lucide-angular'
+import { LucideAngularModule, Menu, ScanQrCode, Sun, Moon, Globe} from 'lucide-angular'
 import { BREAKPOINT } from 'src/types';
 import { SideContainerService } from '@app/components/base-components/side-container/side-container.service';
+import { DropDownComponent } from '../base-components/drop-down/drop-down.component';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
     selector: 'app-nav-bar',
@@ -19,6 +21,7 @@ import { SideContainerService } from '@app/components/base-components/side-conta
         RouterModule,
         LoginComponent,
         LucideAngularModule,
+        DropDownComponent
     ],
     templateUrl: './nav-bar.component.html',
     styleUrls: ['./nav-bar.component.scss']
@@ -28,6 +31,7 @@ export class NavBarComponent implements OnInit, OnDestroy {
     readonly QrIcon = ScanQrCode
     readonly SunIcon = Sun
     readonly MoonIcon = Moon
+    readonly GlobeIcon = Globe
 
     isDarkTheme = false;
     isMobileView = false;
@@ -39,6 +43,7 @@ export class NavBarComponent implements OnInit, OnDestroy {
         private store: Store<AppState>,
         private breakpointObserver: BreakpointObserver,
         private sideContainerService: SideContainerService,
+        private translate: TranslateService,
     ) {}
 
     ngOnInit() {
@@ -65,6 +70,10 @@ export class NavBarComponent implements OnInit, OnDestroy {
 
     toggleMobileSideMenu() {
         this.sideContainerService.toggle('mobile-side-menu');
+    }
+
+    setLang( l: string ) {
+        this.translate.use(l)
     }
 
     ngOnDestroy() {

--- a/src/app/components/nav-bar/nav-bar.component.ts
+++ b/src/app/components/nav-bar/nav-bar.component.ts
@@ -7,7 +7,7 @@ import { RouterModule } from '@angular/router';
 import { LoginComponent } from '../login/login.component';
 import { Subject, takeUntil } from 'rxjs';
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { LucideAngularModule, Menu, ScanQrCode, Sun, Moon, Globe} from 'lucide-angular'
+import { LucideAngularModule, Menu, ScanQrCode, Sun, Moon, Globe, Settings} from 'lucide-angular'
 import { BREAKPOINT } from 'src/types';
 import { SideContainerService } from '@app/components/base-components/side-container/side-container.service';
 import { DropDownComponent } from '../base-components/drop-down/drop-down.component';
@@ -34,6 +34,7 @@ export class NavBarComponent implements OnInit, OnDestroy {
     readonly SunIcon = Sun
     readonly MoonIcon = Moon
     readonly GlobeIcon = Globe
+    readonly SettingsIcon = Settings
 
     isDarkTheme = false;
     isMobileView = false;

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.html
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.html
@@ -1,21 +1,8 @@
 <app-side-container class="c-side-menu" id="mobile-side-menu" side="right">
 
-    <p class="c-side-menu__header">Mobile side-menu head</p>
-
-    <hr class="c-side-menu__separator">
-
-    <a class="c-side-menu__option" routerLink="/trade" routerLinkActive="active-link">
-        <lucide-icon [img]="ChartCandlestickIcon"></lucide-icon>
-        <p>{{'PAGES.TRADE.NAME' | translate}}</p>
-    </a>
-    <a class="c-side-menu__option" routerLink="/explore" routerLinkActive="active-link">
-        <lucide-icon [img]="ListTreeIcon"></lucide-icon>
-        <p>{{'PAGES.EXPLORE.NAME' | translate}}</p>
-    </a>
-    <a class="c-side-menu__option" routerLink="/pool" routerLinkActive="active-link">
-        <lucide-icon [img]="CoinsIcon"></lucide-icon>
-        <p>{{'PAGES.POOL.NAME' | translate}}</p>
-    </a>
+    <p class="c-side-menu__header">
+        <app-login></app-login>
+    </p>
 
     <hr class="c-side-menu__separator">
 
@@ -24,15 +11,17 @@
         <p>{{'PAGES.WALLET.NAME' | translate}}</p>
     </a>
 
+    <a class="c-side-menu__option" routerLink="/accounts" routerLinkActive="active-link">
+        <lucide-icon [img]="UsersIcon"></lucide-icon>
+        <p>{{'PAGES.ACCOUNTS.NAME' | translate}}</p>
+    </a>
+
     <a class="c-side-menu__option" routerLink="/preferences" routerLinkActive="active-link">
         <lucide-icon [img]="SettingsIcon"></lucide-icon>
         <p>{{'PAGES.PREFERENCES.NAME' | translate}}</p>
     </a>
 
-    <a class="c-side-menu__option" routerLink="/accounts" routerLinkActive="active-link">
-        <lucide-icon [img]="UsersIcon"></lucide-icon>
-        <p>{{'PAGES.ACCOUNTS.NAME' | translate}}</p>
-    </a>
+    <hr class="c-side-menu__separator">
 
     <a class="c-side-menu__option" routerLink="/" routerLinkActive="active-link" (click)="logout()">
         <lucide-icon [img]="LogoutIcon"></lucide-icon>

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.html
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.html
@@ -6,37 +6,37 @@
 
     <a class="c-side-menu__option" routerLink="/trade" routerLinkActive="active-link">
         <lucide-icon [img]="ChartCandlestickIcon"></lucide-icon>
-        <p>Trade</p>
+        <p>{{'PAGES.TRADE.NAME' | translate}}</p>
     </a>
     <a class="c-side-menu__option" routerLink="/explore" routerLinkActive="active-link">
         <lucide-icon [img]="ListTreeIcon"></lucide-icon>
-        <p>Explore</p>
+        <p>{{'PAGES.EXPLORE.NAME' | translate}}</p>
     </a>
     <a class="c-side-menu__option" routerLink="/pool" routerLinkActive="active-link">
         <lucide-icon [img]="CoinsIcon"></lucide-icon>
-        <p>Pool</p>
+        <p>{{'PAGES.POOL.NAME' | translate}}</p>
     </a>
 
     <hr class="c-side-menu__separator">
 
     <a class="c-side-menu__option" routerLink="/wallet" routerLinkActive="active-link">
         <lucide-icon [img]="WalletIcon"></lucide-icon>
-        <p>Wallet</p>
+        <p>{{'PAGES.WALLET.NAME' | translate}}</p>
     </a>
 
     <a class="c-side-menu__option" routerLink="/preferences" routerLinkActive="active-link">
         <lucide-icon [img]="SettingsIcon"></lucide-icon>
-        <p>Preferences</p>
+        <p>{{'PAGES.PREFERENCES.NAME' | translate}}</p>
     </a>
 
     <a class="c-side-menu__option" routerLink="/accounts" routerLinkActive="active-link">
         <lucide-icon [img]="UsersIcon"></lucide-icon>
-        <p>Accounts</p>
+        <p>{{'PAGES.ACCOUNTS.NAME' | translate}}</p>
     </a>
 
     <a class="c-side-menu__option" routerLink="/" routerLinkActive="active-link" (click)="logout()">
         <lucide-icon [img]="LogoutIcon"></lucide-icon>
-        <p>Logout</p>
+        <p>{{'TYPES.BUTTON.LOGOUT' | translate}}</p>
     </a>
 
 </app-side-container>

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.scss
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.scss
@@ -4,9 +4,8 @@
 
     &__header{
         color: var(--c-foreground-2);
-        border: 1px solid var(--c-background-1);
         border-radius: 10px;
-        padding: 30px 20px;
+        padding: 20px 20px;
         margin: 0px 0px 10px 0px;
     }
 

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
@@ -12,6 +12,7 @@ import {
 } from 'lucide-angular';
 import { RouterModule } from '@angular/router';
 import { SessionService } from '@app/services/session-kit.service';
+import { SharedModule } from '@app/shared/shared.module';
 
 @Component({
     selector: 'app-side-menu-mobile',
@@ -19,6 +20,7 @@ import { SessionService } from '@app/services/session-kit.service';
         SideContainerComponent,
         LucideAngularModule,
         RouterModule,
+        SharedModule
     ],
     templateUrl: './side-menu-mobile.component.html',
     styleUrl: './side-menu-mobile.component.scss'

--- a/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
+++ b/src/app/components/side-menu-mobile/side-menu-mobile.component.ts
@@ -13,6 +13,7 @@ import {
 import { RouterModule } from '@angular/router';
 import { SessionService } from '@app/services/session-kit.service';
 import { SharedModule } from '@app/shared/shared.module';
+import { LoginComponent } from '../login/login.component';
 
 @Component({
     selector: 'app-side-menu-mobile',
@@ -20,7 +21,8 @@ import { SharedModule } from '@app/shared/shared.module';
         SideContainerComponent,
         LucideAngularModule,
         RouterModule,
-        SharedModule
+        SharedModule,
+        LoginComponent
     ],
     templateUrl: './side-menu-mobile.component.html',
     styleUrl: './side-menu-mobile.component.scss'

--- a/src/app/components/token-transfer-form/token-transfer-form.component.html
+++ b/src/app/components/token-transfer-form/token-transfer-form.component.html
@@ -2,7 +2,7 @@
     <!-- Form View -->
     <div *ngIf="transferStatus.state === 'none'" class="c-token-transfer__container">
         <div class="c-token-transfer__header">
-            <p class="c-token-transfer__header-text">Available:</p>
+            <p class="c-token-transfer__header-text">{{ 'COMPONENTS.TRANSFER-FORM.AVAILABLE' | translate }}</p>
             <p class="c-token-transfer__header-balance">
                 {{ balance?.amount?.formatted }} {{ balance?.token?.symbol }}
             </p>
@@ -11,30 +11,30 @@
         <form class="c-token-transfer__form" [formGroup]="form" (ngSubmit)="transfer()">
             <!-- Recipient Input -->
             <div class="c-token-transfer__input-container">
-                <label class="c-token-transfer__form-title" for="recipient">Transfer to:</label>
-                <input class="c-token-transfer__form-input" id="recipient" type="text" formControlName="recipient" placeholder="Enter destiny username" />
+                <label class="c-token-transfer__form-title" for="recipient">{{ 'COMPONENTS.TRANSFER-FORM.TO.TITLE' | translate }}</label>
+                <input class="c-token-transfer__form-input" id="recipient" type="text" formControlName="recipient" placeholder="{{ 'COMPONENTS.TRANSFER-FORM.TO.INPUT' | translate }}" />
 
                 <p *ngIf="form.get('recipient')?.value" class="c-token-transfer__status">
-                    <span *ngIf="form.get('recipient')?.pending" class="c-token-transfer__status-checking">⏳ Checking account...</span>
-                    <span *ngIf="form.get('recipient')?.errors?.['pattern']" class="c-token-transfer__status-invalid">❌ Wrong EOSIO pattern, 1-12 characters (a-z, 1-5)</span>
-                    <span *ngIf="form.get('recipient')?.errors?.['selfTransfer']" class="c-token-transfer__status-invalid">❌ Cannot send tokens to yourself</span>
-                    <span *ngIf="form.get('recipient')?.errors?.['accountNotFound']" class="c-token-transfer__status-invalid">❌ Account does not exist</span>
-                    <span *ngIf="form.get('recipient')?.valid && !form.get('recipient')?.pending" class="c-token-transfer__status-valid">✅ Verified Account</span>
+                    <span *ngIf="form.get('recipient')?.pending" class="c-token-transfer__status-checking">{{ 'COMPONENTS.TRANSFER-FORM.TO.VALIDATION.CHECKING' | translate }}</span>
+                    <span *ngIf="form.get('recipient')?.errors?.['pattern']" class="c-token-transfer__status-invalid">{{ 'COMPONENTS.TRANSFER-FORM.TO.VALIDATION.INVALID-PATTERN' | translate }}</span>
+                    <span *ngIf="form.get('recipient')?.errors?.['selfTransfer']" class="c-token-transfer__status-invalid">{{ 'COMPONENTS.TRANSFER-FORM.TO.VALIDATION.INVALID-SELF' | translate }}</span>
+                    <span *ngIf="form.get('recipient')?.errors?.['accountNotFound']" class="c-token-transfer__status-invalid">{{ 'COMPONENTS.TRANSFER-FORM.TO.VALIDATION.INVALID-EXIST' | translate }}</span>
+                    <span *ngIf="form.get('recipient')?.valid && !form.get('recipient')?.pending" class="c-token-transfer__status-valid">{{ 'COMPONENTS.TRANSFER-FORM.TO.VALIDATION.VALID' | translate }}</span>
                 </p>
             </div>
 
             <!-- Amount Input -->
             <div class="c-token-transfer__input-container">
                 <div class="c-token-transfer__input-container-bar">
-                    <label class="c-token-transfer__form-title" for="amount">Amount:</label>
-                    <a *ngIf="!isMaxAmount()" class="c-token-transfer__form-max" (click)="useMax()">Use Max</a>
+                    <label class="c-token-transfer__form-title" for="amount">{{ 'COMPONENTS.TRANSFER-FORM.AMOUNT.TITLE' | translate }}</label>
+                    <a *ngIf="!isMaxAmount()" class="c-token-transfer__form-max" (click)="useMax()">{{ 'COMPONENTS.TRANSFER-FORM.AMOUNT.USE-MAX' | translate }}</a>
                 </div>
-                <input class="c-token-transfer__form-input" id="amount" type="text" formControlName="amount" placeholder="Enter whole number" autocomplete="off" />
+                <input class="c-token-transfer__form-input" id="amount" type="text" formControlName="amount" placeholder="{{ 'COMPONENTS.TRANSFER-FORM.AMOUNT.INPUT' | translate }}" autocomplete="off" />
 
                 <p *ngIf="form.get('amount')?.value !== null" class="c-token-transfer__status">
-                    <span *ngIf="form.get('amount')?.errors?.['invalidAmount']" class="c-token-transfer__status-invalid">❌ Invalid amount</span>
-                    <span *ngIf="form.get('amount')?.errors?.['outOfBalance']" class="c-token-transfer__status-invalid">❌ Amount exceeds balance</span>
-                    <span *ngIf="form.get('amount')?.valid" class="c-token-transfer__status-valid">✅ Amount is within balance</span>
+                    <span *ngIf="form.get('amount')?.errors?.['invalidAmount']" class="c-token-transfer__status-invalid">{{ 'COMPONENTS.TRANSFER-FORM.AMOUNT.VALIDATION.INVALID-AMOUNT' | translate }}</span>
+                    <span *ngIf="form.get('amount')?.errors?.['outOfBalance']" class="c-token-transfer__status-invalid">{{ 'COMPONENTS.TRANSFER-FORM.AMOUNT.VALIDATION.INVALID-MAX' | translate }}</span>
+                    <span *ngIf="form.get('amount')?.valid" class="c-token-transfer__status-valid">{{ 'COMPONENTS.TRANSFER-FORM.AMOUNT.VALIDATION.VALID' | translate }}</span>
                 </p>
             </div>
 
@@ -49,7 +49,7 @@
                     type="submit"
                     [disabled]="form.invalid || isLoading"
                 >
-                    {{ isLoading ? 'Processing...' : 'Transfer' }}
+                    {{ isLoading ? ['TYPES.BUTTON.PROCESSING' | translate] : ['TYPES.BUTTON.TRANSFER' | translate] }}
                 </button>
             </div>
         </form>
@@ -58,15 +58,15 @@
     <!-- Success View -->
     <div *ngIf="transferStatus.state === 'success'" class="c-token-transfer__container">
         <p class="c-token-transfer__result">
-            <strong class="c-token-transfer__result-success">✅ Successful Transfer</strong>
+            <strong class="c-token-transfer__result-success">{{'COMPONENTS.TRANSFER-FORM.SUCCSES' | translate}}</strong>
         </p>
 
         <!-- Display transaction summary -->
         <div class="c-token-transfer__summary-box" *ngIf="transferStatus.summary">
-            <p><strong>From:</strong> {{ transferStatus.summary.from }}</p>
-            <p><strong>To:</strong> {{ transferStatus.summary.to }}</p>
-            <p><strong>Amount:</strong> {{ transferStatus.summary.amount }}</p>
-            <p><strong>Transaction:</strong>
+            <p><strong>{{ 'TYPES.TRANSFER-SUMMARY.FROM' | translate }}</strong> {{ transferStatus.summary.from }}</p>
+            <p><strong>{{ 'TYPES.TRANSFER-SUMMARY.TO' | translate }}</strong> {{ transferStatus.summary.to }}</p>
+            <p><strong>{{ 'TYPES.TRANSFER-SUMMARY.AMOUNT' | translate }}</strong> {{ transferStatus.summary.amount }}</p>
+            <p><strong>{{ 'TYPES.TRANSFER-SUMMARY.TRANSACTION' | translate }}</strong>
                 <a [href]="'https://explorer.telos.net/transaction/' + transferStatus.summary.transaction" target="_blank">
                     {{ transferStatus.summary.transaction.substring(0, 10) }} <!-- ✅ Shorten only in UI -->
                 </a>
@@ -74,7 +74,7 @@
         </div>
 
         <div class="c-token-transfer__input-buttons">
-            <button class="c-token-transfer__form-button c-token-transfer__form-button--available" (click)="close()">Close</button>
+            <button class="c-token-transfer__form-button c-token-transfer__form-button--available" (click)="close()">{{'TYPES.BUTTON.CLOSE' | translate}}</button>
         </div>
     </div>
 
@@ -82,14 +82,14 @@
     <div *ngIf="transferStatus.state === 'failure'" class="c-token-transfer__container">
         <p class="c-token-transfer__result">
             <strong class="c-token-transfer__result-fail">
-                ❌ Transfer Failed
+                {{'COMPONENTS.TRANSFER-FORM.FAILURE' | translate}}
             </strong>
         </p>
         <p class="c-token-transfer__error-message">{{ transferStatus.message }}</p>
 
         <div class="c-token-transfer__input-buttons">
-            <button class="c-token-transfer__form-button c-token-transfer__form-button--available" (click)="retry()">Retry</button>
-            <button class="c-token-transfer__form-button c-token-transfer__form-button--available" (click)="close()">Close</button>
+            <button class="c-token-transfer__form-button c-token-transfer__form-button--available" (click)="retry()">{{'TYPES.BUTTON.RETRY' | translate}}</button>
+            <button class="c-token-transfer__form-button c-token-transfer__form-button--available" (click)="close()">{{'TYPES.BUTTON.CLOSE' | translate}}</button>
         </div>
     </div>
 </div>

--- a/src/app/components/token-transfer-form/token-transfer-form.component.scss
+++ b/src/app/components/token-transfer-form/token-transfer-form.component.scss
@@ -23,6 +23,11 @@
     }
 
     &__form {
+        &-title{
+            font-size: 14px;
+            color: var(--c-foreground-2);
+            margin: 0px;
+        }
         &-input {
             @include input;
         }

--- a/src/app/components/token-transfer-form/token-transfer-form.component.ts
+++ b/src/app/components/token-transfer-form/token-transfer-form.component.ts
@@ -10,11 +10,16 @@ import { Subject, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs';
 import { AbstractControl } from '@angular/forms';
 import { timer, of, catchError, map, switchMap } from 'rxjs';
 import { ExpandableManagerService } from '@app/components/base-components/expandable/expandable-manager.service';
+import { SharedModule } from '@app/shared/shared.module';
 
 @Component({
     selector: 'app-token-transfer-form',
     standalone: true,
-    imports: [CommonModule, ReactiveFormsModule],
+    imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        SharedModule
+    ],
     templateUrl: './token-transfer-form.component.html',
     styleUrls: ['./token-transfer-form.component.scss']
 })

--- a/src/app/components/user-side-menu/user-side-menu.component.html
+++ b/src/app/components/user-side-menu/user-side-menu.component.html
@@ -1,8 +1,6 @@
-<app-side-container class="c-side-menu" id="mobile-side-menu" side="right">
+<app-side-container class="c-side-menu" id="user-side-menu" side="right">
 
-    <p class="c-side-menu__header">
-        <app-login></app-login>
-    </p>
+    <p class="c-side-menu__header">User side-menu head</p>
 
     <hr class="c-side-menu__separator">
 

--- a/src/app/components/user-side-menu/user-side-menu.component.scss
+++ b/src/app/components/user-side-menu/user-side-menu.component.scss
@@ -4,8 +4,9 @@
 
     &__header{
         color: var(--c-foreground-2);
+        border: 1px solid var(--c-background-1);
         border-radius: 10px;
-        padding: 20px 20px;
+        padding: 30px 20px;
         margin: 0px 0px 10px 0px;
     }
 

--- a/src/app/components/user-side-menu/user-side-menu.component.ts
+++ b/src/app/components/user-side-menu/user-side-menu.component.ts
@@ -13,21 +13,19 @@ import {
 import { RouterModule } from '@angular/router';
 import { SessionService } from '@app/services/session-kit.service';
 import { SharedModule } from '@app/shared/shared.module';
-import { LoginComponent } from '../login/login.component';
 
 @Component({
-    selector: 'app-side-menu-mobile',
+    selector: 'app-user-side-menu',
     imports: [
         SideContainerComponent,
         LucideAngularModule,
         RouterModule,
-        SharedModule,
-        LoginComponent
+        SharedModule
     ],
-    templateUrl: './side-menu-mobile.component.html',
-    styleUrl: './side-menu-mobile.component.scss'
+    templateUrl: './user-side-menu.component.html',
+    styleUrl: './user-side-menu.component.scss'
 })
-export class SideMenuMobileComponent {
+export class UserSideMenuComponent {
     readonly ChartCandlestickIcon = ChartCandlestick;
     readonly SettingsIcon = Settings;
     readonly CoinsIcon = Coins;

--- a/src/app/pages/accounts/accounts.component.html
+++ b/src/app/pages/accounts/accounts.component.html
@@ -1,14 +1,15 @@
 <div class="p-accounts">
-    <div class="p-accounts__title">Accounts</div>
+    <div class="p-accounts__title">{{ 'PAGES.ACCOUNTS.TITLE' | translate}}</div>
+    <p>{{ 'PAGES.ACCOUNTS.DESCRIPTION' | translate}}</p>
 
     <ng-container *ngIf="sessionService.session$ | async as session; else loginTemplate">
-        <p class="p-accounts__subtitle">Connected as: {{ session.actor }}</p>
-        <p class="p-accounts__contained"> Accounts list goes here <br>-<br>-<br>-</p>
-        <a class="p-accounts__add">+ Add new account</a>
+        <p class="p-accounts__subtitle">{{ 'PAGES.ACCOUNTS.CONNECTED' | translate}} {{ session.actor }}</p>
+        <p class="p-accounts__contained">-<br>-<br>-<br>-</p>
+        <a class="p-accounts__add">+ {{ 'PAGES.ACCOUNTS.ADD' | translate}}</a>
     </ng-container>
 
     <ng-template #loginTemplate>
-        <p class="p-accounts__subtitle">Please log in to continue</p>
+        <p class="p-accounts__subtitle">{{ 'PAGES.ACCOUNTS.ERROR' | translate}}</p>
         <app-login></app-login>
     </ng-template>
 </div>

--- a/src/app/pages/accounts/accounts.component.html
+++ b/src/app/pages/accounts/accounts.component.html
@@ -4,12 +4,12 @@
 
     <ng-container *ngIf="sessionService.session$ | async as session; else loginTemplate">
         <p class="p-accounts__subtitle">{{ 'PAGES.ACCOUNTS.CONNECTED' | translate}} {{ session.actor }}</p>
-        <p class="p-accounts__contained">-<br>-<br>-<br>-</p>
-        <a class="p-accounts__add">+ {{ 'PAGES.ACCOUNTS.ADD' | translate}}</a>
     </ng-container>
 
     <ng-template #loginTemplate>
         <p class="p-accounts__subtitle">{{ 'PAGES.ACCOUNTS.ERROR' | translate}}</p>
-        <app-login></app-login>
     </ng-template>
+
+    <p class="p-accounts__contained">-<br>-<br>-<br>-</p>
+    <a class="p-accounts__add">+ {{ 'PAGES.ACCOUNTS.ADD' | translate}}</a>
 </div>

--- a/src/app/pages/accounts/accounts.component.ts
+++ b/src/app/pages/accounts/accounts.component.ts
@@ -2,11 +2,16 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LoginComponent } from '@app/components/login/login.component';
 import { SessionService } from '@app/services/session-kit.service';
+import { SharedModule } from '@app/shared/shared.module';
 
 @Component({
     selector: 'app-accounts',
     standalone: true,
-    imports: [CommonModule, LoginComponent],
+    imports: [
+        CommonModule,
+        LoginComponent,
+        SharedModule
+    ],
     templateUrl: './accounts.component.html',
     styleUrls: ['./accounts.component.scss']
 })

--- a/src/app/pages/accounts/accounts.component.ts
+++ b/src/app/pages/accounts/accounts.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { LoginComponent } from '@app/components/login/login.component';
 import { SessionService } from '@app/services/session-kit.service';
 import { SharedModule } from '@app/shared/shared.module';
 
@@ -9,7 +8,6 @@ import { SharedModule } from '@app/shared/shared.module';
     standalone: true,
     imports: [
         CommonModule,
-        LoginComponent,
         SharedModule
     ],
     templateUrl: './accounts.component.html',

--- a/src/app/pages/pool/pool.component.ts
+++ b/src/app/pages/pool/pool.component.ts
@@ -1,12 +1,14 @@
 import { Component } from '@angular/core';
+import { SharedModule } from '@app/shared/shared.module';
 
 @Component({
     standalone: true,
     selector: 'app-pool',
+    imports: [SharedModule],
     template: `
         <div class="p-pool">
-            <div class="p-pool__title">Pool Page</div>
-            <p class="p-pool__subtitle">Manage your liquidity here!</p>
+            <div class="p-pool__title">{{ 'PAGES.POOL.TITLE' | translate }}</div>
+            <p class="p-pool__subtitle">{{ 'PAGES.POOL.DESCRIPTION' | translate }}</p>
         </div>
     `,
     styleUrls: ['./pool.component.scss']

--- a/src/app/pages/preferences/preferences.component.html
+++ b/src/app/pages/preferences/preferences.component.html
@@ -3,9 +3,9 @@
     <p>{{ 'PAGES.PREFERENCES.DESCRIPTION' | translate }}</p>
     <div class="p-preferences__section">
         <h3>{{ 'PAGES.PREFERENCES.LANGUAGE.TITLE' | translate }}</h3>
-        <div dropdown-body class="p-preferences__dropdown">
-            <a class="p-preferences__dropdown-option" (click)="setLang('en')">{{ 'PAGES.PREFERENCES.LANGUAGE.EN' | translate }}</a>
-            <a class="p-preferences__dropdown-option" (click)="setLang('es')">{{ 'PAGES.PREFERENCES.LANGUAGE.ES' | translate }}</a>
+        <div class="p-preferences__lang">
+            <a class="p-preferences__lang-option" (click)="setLang('en')">{{ 'PAGES.PREFERENCES.LANGUAGE.EN' | translate }}</a>
+            <a class="p-preferences__lang-option" (click)="setLang('es')">{{ 'PAGES.PREFERENCES.LANGUAGE.ES' | translate }}</a>
         </div>
     </div>
     <div class="p-preferences__section">

--- a/src/app/pages/preferences/preferences.component.html
+++ b/src/app/pages/preferences/preferences.component.html
@@ -1,7 +1,14 @@
-<div class="c-preferences">
+<div class="p-preferences">
     <h2>{{ 'PAGES.PREFERENCES.TITLE' | translate }}</h2>
     <p>{{ 'PAGES.PREFERENCES.DESCRIPTION' | translate }}</p>
-    <div class="c-preferences__section">
+    <div class="p-preferences__section">
+        <h3>{{ 'PAGES.PREFERENCES.LANGUAGE.TITLE' | translate }}</h3>
+        <div dropdown-body class="p-preferences__dropdown">
+            <a class="p-preferences__dropdown-option" (click)="setLang('en')">{{ 'PAGES.PREFERENCES.LANGUAGE.EN' | translate }}</a>
+            <a class="p-preferences__dropdown-option" (click)="setLang('es')">{{ 'PAGES.PREFERENCES.LANGUAGE.ES' | translate }}</a>
+        </div>
+    </div>
+    <div class="p-preferences__section">
         <h3>{{ 'PAGES.PREFERENCES.MODE.TITLE' | translate }}</h3>
         <app-toggle [currentState]="(currentState$ | async) ?? 0" (stateChange)="onStateChange($event)">
             <ng-template #stateContent>
@@ -12,12 +19,12 @@
             </ng-template>
         </app-toggle>
     </div>
-    <div class="c-preferences__section">
+    <div class="p-preferences__section">
         <h3>{{ 'PAGES.PREFERENCES.HUE.TITLE' | translate }}</h3>
-        <div class="c-preferences__theme-selector">
-            <p class="c-preferences__btn-default-theme" (click)="setHueTheme('default')">{{ 'PAGES.PREFERENCES.HUE.A' | translate }}</p>
-            <p class="c-preferences__btn-igneous-theme" (click)="setHueTheme('igneous')">{{ 'PAGES.PREFERENCES.HUE.B' | translate }}</p>
-            <p class="c-preferences__btn-emerald-theme" (click)="setHueTheme('emerald')">{{ 'PAGES.PREFERENCES.HUE.C' | translate }}</p>
+        <div class="p-preferences__theme-selector">
+            <p class="p-preferences__btn-default-theme" (click)="setHueTheme('default')">{{ 'PAGES.PREFERENCES.HUE.A' | translate }}</p>
+            <p class="p-preferences__btn-igneous-theme" (click)="setHueTheme('igneous')">{{ 'PAGES.PREFERENCES.HUE.B' | translate }}</p>
+            <p class="p-preferences__btn-emerald-theme" (click)="setHueTheme('emerald')">{{ 'PAGES.PREFERENCES.HUE.C' | translate }}</p>
         </div>
     </div>
 </div>

--- a/src/app/pages/preferences/preferences.component.html
+++ b/src/app/pages/preferences/preferences.component.html
@@ -1,22 +1,23 @@
 <div class="c-preferences">
-    <h2>User Preferences</h2>
+    <h2>{{ 'PAGES.PREFERENCES.TITLE' | translate }}</h2>
+    <p>{{ 'PAGES.PREFERENCES.DESCRIPTION' | translate }}</p>
     <div class="c-preferences__section">
-        <h3>Mode</h3>
+        <h3>{{ 'PAGES.PREFERENCES.MODE.TITLE' | translate }}</h3>
         <app-toggle [currentState]="(currentState$ | async) ?? 0" (stateChange)="onStateChange($event)">
             <ng-template #stateContent>
-                <p>Dark</p>
+                <p>{{ 'PAGES.PREFERENCES.MODE.DARK' | translate }}</p>
             </ng-template>
             <ng-template #stateContent>
-                <p>Light</p>
+                <p>{{ 'PAGES.PREFERENCES.MODE.LIGHT' | translate }}</p>
             </ng-template>
         </app-toggle>
     </div>
     <div class="c-preferences__section">
-        <h3>Hue</h3>
+        <h3>{{ 'PAGES.PREFERENCES.HUE.TITLE' | translate }}</h3>
         <div class="c-preferences__theme-selector">
-            <p class="c-preferences__btn-default-theme" (click)="setHueTheme('default')">Default</p>
-            <p class="c-preferences__btn-igneous-theme" (click)="setHueTheme('igneous')">Igneous</p>
-            <p class="c-preferences__btn-emerald-theme" (click)="setHueTheme('emerald')">Emerald</p>
+            <p class="c-preferences__btn-default-theme" (click)="setHueTheme('default')">{{ 'PAGES.PREFERENCES.HUE.A' | translate }}</p>
+            <p class="c-preferences__btn-igneous-theme" (click)="setHueTheme('igneous')">{{ 'PAGES.PREFERENCES.HUE.B' | translate }}</p>
+            <p class="c-preferences__btn-emerald-theme" (click)="setHueTheme('emerald')">{{ 'PAGES.PREFERENCES.HUE.C' | translate }}</p>
         </div>
     </div>
 </div>

--- a/src/app/pages/preferences/preferences.component.scss
+++ b/src/app/pages/preferences/preferences.component.scss
@@ -4,11 +4,23 @@
     @include page;
 }
 
-.c-preferences {
+.p-preferences {
+    width: 100%;
+    max-width: 500px;
     display: flex;
     flex-direction: column;
     gap: 20px;
-    border-radius: 10px;
+
+    &__dropdown{
+        display: flex;
+        flex-direction: column;
+        gap: 15px;
+        padding: 10px;
+
+        &-option{
+            @include hyperlink
+        }
+    }
 
     &__btn-default-theme {
         @include button-0;

--- a/src/app/pages/preferences/preferences.component.scss
+++ b/src/app/pages/preferences/preferences.component.scss
@@ -11,7 +11,7 @@
     flex-direction: column;
     gap: 20px;
 
-    &__dropdown{
+    &__lang{
         display: flex;
         flex-direction: column;
         gap: 15px;

--- a/src/app/pages/preferences/preferences.component.ts
+++ b/src/app/pages/preferences/preferences.component.ts
@@ -7,6 +7,8 @@ import { Observable, Subject } from 'rxjs';
 import { map, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { ToggleComponent } from '@app/components/base-components/toggle/toggle.component';
 import { SharedModule } from '@app/shared/shared.module';
+import { LucideAngularModule, Globe } from 'lucide-angular';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
     selector: 'app-preferences',
@@ -14,12 +16,15 @@ import { SharedModule } from '@app/shared/shared.module';
     imports: [
         CommonModule,
         ToggleComponent,
-        SharedModule
+        SharedModule,
+        LucideAngularModule
     ],
     templateUrl: './preferences.component.html',
     styleUrls: ['./preferences.component.scss']
 })
 export class PreferencesComponent implements OnInit, OnDestroy {
+    readonly GlobeIcon = Globe
+
     hue0$: Observable<number>;
     hue1$: Observable<number>;
     currentState$: Observable<number>;
@@ -29,7 +34,10 @@ export class PreferencesComponent implements OnInit, OnDestroy {
     private hue1Subject = new Subject<number>();
     private destroy$ = new Subject<void>(); // Cleanup subject
 
-    constructor(private store: Store<AppState>) {
+    constructor(
+        private translate: TranslateService,
+        private store: Store<AppState>
+    ) {
         this.hue0$ = this.store.pipe(select(user.selectors.hue0));
         this.hue1$ = this.store.pipe(select(user.selectors.hue1));
 
@@ -77,6 +85,10 @@ export class PreferencesComponent implements OnInit, OnDestroy {
                 this.store.dispatch(user.actions.setLight());
                 break;
         }
+    }
+
+    setLang( l: string ) {
+        this.translate.use(l)
     }
 
     setHueTheme(theme: 'default' | 'igneous' | 'emerald') {

--- a/src/app/pages/preferences/preferences.component.ts
+++ b/src/app/pages/preferences/preferences.component.ts
@@ -6,11 +6,16 @@ import { user } from '@app/store/user';
 import { Observable, Subject } from 'rxjs';
 import { map, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { ToggleComponent } from '@app/components/base-components/toggle/toggle.component';
+import { SharedModule } from '@app/shared/shared.module';
 
 @Component({
     selector: 'app-preferences',
     standalone: true,
-    imports: [CommonModule, ToggleComponent],
+    imports: [
+        CommonModule,
+        ToggleComponent,
+        SharedModule
+    ],
     templateUrl: './preferences.component.html',
     styleUrls: ['./preferences.component.scss']
 })

--- a/src/app/pages/trade/trade.component.ts
+++ b/src/app/pages/trade/trade.component.ts
@@ -1,13 +1,14 @@
 import { Component } from '@angular/core';
+import { SharedModule } from '@app/shared/shared.module';
 
 @Component({
     standalone: true,
     selector: 'app-trade',
-    imports: [],
+    imports: [SharedModule],
     template: `
         <div class="p-trade">
-            <div class="p-trade__title">Trade Page</div>
-            <p class="p-trade__subtitle">Perform your trades here!</p>
+            <div class="p-trade__title">{{ 'PAGES.TRADE.TITLE' | translate }}</div>
+            <p class="p-trade__subtitle">{{ 'PAGES.TRADE.DESCRIPTION' | translate }}</p>
         </div>
     `,
     styleUrls: ['./trade.component.scss']

--- a/src/app/pages/wallet/wallet.component.html
+++ b/src/app/pages/wallet/wallet.component.html
@@ -5,15 +5,15 @@
 >
     <div class="p-wallet__header">
         <div class="p-wallet__header-title">
-            Wallet
+            {{ 'PAGES.WALLET.TITLE' | translate }}
         </div>
         <div class="p-wallet__header-subtitle">
-            Balance of your tokens
+            {{ 'PAGES.WALLET.DESCRIPTION' | translate }}
         </div>
     </div>
 
     <div class="p-wallet__loading" *ngIf="loading; else balanceList">
-        <p>[ Loading... ]</p>
+        <p>{{ 'PAGES.WALLET.LOADING' | translate }}</p>
     </div>
 
     <ng-template #balanceList>
@@ -32,7 +32,7 @@
                 <!-- Open Header: (Optional) Show Same or Different Info When Expanded -->
                 <div class="p-wallet__balance-head p-wallet__balance-head--open" openHeader>
                     <img class="p-wallet__balance-icon" src="{{ balance.token.logo }}">
-                    <p>Transfer {{ balance.token.symbol }}</p>
+                    <p>{{ 'COMPONENTS.TRANSFER-FORM.TITLE' | translate }} {{ balance.token.symbol }}</p>
                 </div>
 
                 <!-- Expandable Body: Show Detailed Info -->
@@ -41,14 +41,14 @@
                 </div>
             </app-expandable>
         </app-expandable-group>
-        <a class="p-wallet__refresh" (click)="refreshBalances()">&#x21bb; Refresh Balances </a>
+        <a class="p-wallet__refresh" (click)="refreshBalances()">&#x21bb; {{ 'TYPES.BUTTON.REFRESH' | translate }} {{ 'PAGES.WALLET.NAME' | translate }}  </a>
     </ng-template>
 </div>
 
 <ng-template #noSession>
     <div class="p-wallet">
         <div class="p-wallet__header-subtitle">
-            No active session. Please log in first.
+            {{ 'PAGES.WALLET.ERROR' | translate }}
         </div>
     </div>
 </ng-template>

--- a/src/app/pages/wallet/wallet.component.ts
+++ b/src/app/pages/wallet/wallet.component.ts
@@ -9,6 +9,8 @@ import { ExpandableGroupComponent } from '@app/components/base-components/expand
 import { TokenTransferFormComponent } from '@app/components/token-transfer-form/token-transfer-form.component';
 import { BREAKPOINT } from 'src/types';
 import { BreakpointObserver } from '@angular/cdk/layout';
+import { SharedModule } from '@app/shared/shared.module';
+
 @Component({
     selector: 'app-wallet',
     standalone: true,
@@ -17,6 +19,7 @@ import { BreakpointObserver } from '@angular/cdk/layout';
         ExpandableComponent,
         ExpandableGroupComponent,
         TokenTransferFormComponent,
+        SharedModule
     ],
     templateUrl: './wallet.component.html',
     styleUrls: ['./wallet.component.scss'],

--- a/src/app/services/local-storage.service.ts
+++ b/src/app/services/local-storage.service.ts
@@ -53,6 +53,6 @@ export class LocalStorageService {
             if (typeof preferences.h0 === 'number' && typeof preferences.h1 === 'number') {
                 this.store.dispatch(user.actions.setHueTheme({ h0: preferences.h0, h1: preferences.h1 }));
             }
-        }
+        } else {this.store.dispatch(user.actions.setDark())}
     }
 }

--- a/src/app/style/_mixin.scss
+++ b/src/app/style/_mixin.scss
@@ -15,7 +15,6 @@
 
 @mixin icon {
     color: var(--c-foreground-2);
-    stroke-width: 1.8;
     width: 26px;
     height: 26px;
 }


### PR DESCRIPTION
# Proposal for enhancing navigation experience

## Problem:
Right now there are two menus when user is in mobile state, the user-drop-down and the side-menu. This duplication is confusing and makes the information seem more than it actually is.

Also, we probably don't want mobile user focusing on the DEX marketplace options, so we could reduce the complexity of the navbar by removing them and transforming the mobile-side-menu to a generic user-side-menu that can only be shown once the user logs in. This way the mobile user has constrained options that focus on the mobile wallet experience.

## TODO:
- [x] Make login button toggle the side menu when session is open
- [x] Change hamburger-icon-tbn to be globe-icon-btn for the language preference
- [x] Remove marketplace in the mobile-side-menu (constrained user options is very powerful!)
- [x] Remove the login button from the accounts page; always show the accounts-list and the +add-user 
- [x] Rename files and ID's from side-menu-mobile to user-side-menu 

![2025-03-28-151824_356x71_scrot](https://github.com/user-attachments/assets/7a776552-565c-4439-99eb-8204ea870102)

![2025-03-28-151849_357x72_scrot](https://github.com/user-attachments/assets/ffd11e25-2417-4803-aaf7-19e8751f5aa2)
![2025-03-28-151903_363x490_scrot](https://github.com/user-attachments/assets/8bb04ab6-9fee-45c7-8226-1121339ae835)
